### PR TITLE
Fork of bissolli/gh-action-persist-workspace

### DIFF
--- a/forks/persist-workspace/.github/workflows/test-with-name.yml
+++ b/forks/persist-workspace/.github/workflows/test-with-name.yml
@@ -1,0 +1,41 @@
+name: Test with name
+
+on:
+  push:
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: First step
+        run: echo "Init is ready"
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: persist
+          artifactName: my-art
+
+  step-a:
+    needs: [init]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: retrieve
+          artifactName: my-art
+      - name: Step A
+        run: echo "This is running from the persisted workspace"
+
+  step-b:
+    needs: [init]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: retrieve
+          artifactName: my-art
+      - name: Step B
+        run: echo "This is running from the persisted workspace"

--- a/forks/persist-workspace/.github/workflows/test.yml
+++ b/forks/persist-workspace/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: First step
+        run: echo "Init is ready"
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: persist
+
+  step-a:
+    needs: [init]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: retrieve
+      - name: Step A
+        run: echo "This is running from the persisted workspace"
+
+  step-b:
+    needs: [init]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: retrieve
+      - name: Step B
+        run: echo "This is running from the persisted workspace"

--- a/forks/persist-workspace/LICENSE
+++ b/forks/persist-workspace/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 thefrustrateddev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/forks/persist-workspace/README.md
+++ b/forks/persist-workspace/README.md
@@ -1,0 +1,112 @@
+# gh-action-persist-workspace
+
+This action will help you to persist your workspace from job to job on your workflow!
+With that you will be able to split your jobs and parallelize them without the need to re-do that basic steps needed for all the jobs.
+
+## Usage
+
+This action use [actions/upload-artifact](https://github.com/actions/upload-artifact) and [actions/download-artifact](https://github.com/actions/download-artifact) under the hood.
+
+### Persist the workspace
+
+```yml
+name: My CI
+
+on:
+  pull_request:
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Install dependencies
+        run: npm install
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: persist
+```
+
+### Retrieve a persisted workspace
+
+```yml
+name: My CI
+
+on:
+  pull_request:
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Install dependencies
+        run: npm install
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: persist
+
+  build:
+    needs: [init]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+      - uses: chatfood/gh-action-persist-workspace@master
+        with:
+          action: retrieve
+      - name: Build the project
+        run: npm run build
+```
+
+
+### Parallelize your jobs with the persisted workspace
+
+```yml
+name: My CI
+
+on:
+  pull_request:
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Install dependencies
+        run: npm install
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: persist
+
+  test:
+    needs: [init]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: retrieve
+      - name: Run unit tests
+        run: npm run test
+
+  build:
+    needs: [init]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+      - uses: bissolli/gh-action-persist-workspace@v1
+        with:
+          action: retrieve
+      - name: Build the project
+        run: npm run build
+```
+
+## Accepted inputs
+
+| Input | Type | Default | Description |
+| --- | --- | --- | --- |
+| action | `persist` or `retrieve` | `persist` | Whether you would like to persist or retrieve the workspace. |
+| artifactName | `string` | persisted-artifact | Name of the generated artifact |

--- a/forks/persist-workspace/action.yml
+++ b/forks/persist-workspace/action.yml
@@ -1,0 +1,41 @@
+name: persist-workspace
+description: 'A action to persist your workspace across different jobs'
+author: bissolli
+branding:
+  icon: 'box'  
+  color: 'green'
+inputs:
+  action:
+    required: false
+    options:
+      - retrieve
+      - persist
+  artifactName:
+    required: false
+
+    
+runs:
+  using: "composite"
+  steps:
+    - name: Create the workspace artifact
+      if: ${{ inputs.action != 'retrieve' }}
+      shell: bash
+      run: tar -cf workspace.tar --exclude=workspace.tar .
+    - name: Upload the workspace artifact
+      if: ${{ inputs.action == 'persist' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.artifactName || 'persisted-artifact' }}
+        path: workspace.tar
+        if-no-files-found: error
+    - name: Retrieve workspace
+      if: ${{ inputs.action == 'retrieve' }}
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.artifactName || 'persisted-artifact' }}
+    - name: Extract workspace
+      if: ${{ inputs.action == 'retrieve' }}
+      shell: bash
+      run: |
+        ls -lah
+        tar -xf workspace.tar


### PR DESCRIPTION
As of Aug 2023, the LICENSE file is MIT, therefore our fork and modifications will also be MIT.

We'll be making some improvements / changes in the next PR to bring it in line with the variant that we've been using internally.

source: https://github.com/bissolli/gh-action-persist-workspace