### PR TITLE
Refactor persist-workspace

### DIFF
--- a/forks/persist-workspace/LICENSE
+++ b/forks/persist-workspace/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2022 thefrustrateddev
+Copyright (c) 2023 Ritter Insurance Marketing
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/forks/persist-workspace/README.md
+++ b/forks/persist-workspace/README.md
@@ -1,7 +1,8 @@
-# gh-action-persist-workspace
+# persist-workspace
 
-This action will help you to persist your workspace from job to job on your workflow!
-With that you will be able to split your jobs and parallelize them without the need to re-do that basic steps needed for all the jobs.
+This action will help you to persist your workspace from job to job on your workflow! With that you will be able to split your jobs and parallelize them without the need to re-do that basic steps needed for all the jobs.
+
+NOTE: The '.git' folder is excluded from the tarball because the '.git/config' file can contain sensistive information.
 
 ## Usage
 
@@ -23,7 +24,7 @@ jobs:
       - uses: actions/setup-node@v3
       - name: Install dependencies
         run: npm install
-      - uses: bissolli/gh-action-persist-workspace@v1
+      - uses: ritterim/forks/persist-workspace@v1
         with:
           action: persist
 ```
@@ -44,7 +45,7 @@ jobs:
       - uses: actions/setup-node@v3
       - name: Install dependencies
         run: npm install
-      - uses: bissolli/gh-action-persist-workspace@v1
+      - uses: ritterim/forks/persist-workspace@v1
         with:
           action: persist
 
@@ -53,9 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v3
-      - uses: chatfood/gh-action-persist-workspace@master
+      - uses: ritterim/forks/persist-workspace@v1
         with:
           action: retrieve
+          artifact_name: ${{ needs.init.outputs.artifact_name }}
       - name: Build the project
         run: npm run build
 ```
@@ -77,7 +79,7 @@ jobs:
       - uses: actions/setup-node@v3
       - name: Install dependencies
         run: npm install
-      - uses: bissolli/gh-action-persist-workspace@v1
+      - uses: ritterim/forks/persist-workspace@v1
         with:
           action: persist
 
@@ -86,9 +88,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v3
-      - uses: bissolli/gh-action-persist-workspace@v1
+      - uses: ritterim/forks/persist-workspace@v1
         with:
           action: retrieve
+          artifact_name: ${{ needs.init.outputs.artifact_name }}
       - name: Run unit tests
         run: npm run test
 
@@ -97,9 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v3
-      - uses: bissolli/gh-action-persist-workspace@v1
+      - uses: ritterim/forks/persist-workspace@v1
         with:
           action: retrieve
+          artifact_name: ${{ needs.init.outputs.artifact_name }}
       - name: Build the project
         run: npm run build
 ```
@@ -109,4 +113,5 @@ jobs:
 | Input | Type | Default | Description |
 | --- | --- | --- | --- |
 | action | `persist` or `retrieve` | `persist` | Whether you would like to persist or retrieve the workspace. |
-| artifactName | `string` | persisted-artifact | Name of the generated artifact |
+| artifact_name | `string` | persisted-artifact | Name of the generated artifact. |
+| retention_days | `number` | 3 | Number of days to keep the artifact. |

--- a/forks/persist-workspace/action.yml
+++ b/forks/persist-workspace/action.yml
@@ -4,38 +4,105 @@ author: bissolli
 branding:
   icon: 'box'  
   color: 'green'
+
 inputs:
+
   action:
+    default: persist
     required: false
+    type: choice
     options:
       - retrieve
       - persist
-  artifactName:
+
+  artifact_name:
+    default: 
     required: false
 
-    
+  retention_days:
+    type: number
+    default: 3
+    required: false
+    description: >
+      Duration after which artifact will expire in days. 0 means using default retention.
+
+      Default 3 days.
+      Minimum 1 day.
+      Maximum 90 days unless changed from the repository settings page.
+
+outputs:
+
+  artifact_name: 
+    description: Name of the artifact which contains the persisted workspace directory.
+    value: ${{ steps.set-outputs.outputs.artifact_name }}
+
+env:
+  ARTIFACTNAME: 
+  TGZFILENAME: workspace.tar.gz
+
 runs:
   using: "composite"
   steps:
-    - name: Create the workspace artifact
-      if: ${{ inputs.action != 'retrieve' }}
+
+    - name: Calculate ARTIFACTNAME
       shell: bash
-      run: tar -cf workspace.tar --exclude=workspace.tar .
+      env:
+        INPUTARTIFACTNAME: ${{ inputs.artifact_name }}
+      run: |
+        GITHUBRUNID=${{ github.run_id }}
+        ARTIFACTNAME=${INPUTARTIFACTNAME:-persisted-workspace-$GITHUBRUNID}
+        echo "ARTIFACTNAME=${ARTIFACTNAME}"
+        echo "ARTIFACTNAME=${ARTIFACTNAME}" >> $GITHUB_ENV
+
+    - name: Validate inputs.artifact_name
+      shell: bash
+      run: |
+        echo "${ARTIFACTNAME}" | grep -E '^[A-Za-z0-9\.-]{10,60}'
+
+    - name: Set TGZFILENAME from ARTIFACTNAME
+      shell: bash
+      run: |
+        echo TGZFILENAME="${ARTIFACTNAME}.tgz"
+        echo TGZFILENAME="${ARTIFACTNAME}.tgz" >> $GITHUB_ENV
+
+    - name: Create artifact folder
+      if: ${{ inputs.action == 'persist' }}
+      shell: bash
+      run: mkdir tmp-persisted-workspace
+
+    - name: Create the workspace artifact
+      if: ${{ inputs.action == 'persist' }}
+      shell: bash
+      run: |
+        tar -czf "tmp-persisted-workspace/${TGZFILENAME}" \
+          --exclude=.git \
+          --exclude=tmp-persisted-workspace \
+          .
+        ls -l tmp-persisted-workspace/
+
     - name: Upload the workspace artifact
       if: ${{ inputs.action == 'persist' }}
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.artifactName || 'persisted-artifact' }}
-        path: workspace.tar
+        name: ${{ env.ARTIFACTNAME }}
+        path: tmp-persisted-workspace/${{ env.TGZFILENAME }}
+        retention-days: ${{ inputs.retention_days }}
         if-no-files-found: error
+
+    - name: Set output variables
+      id: set-outputs
+      shell: bash
+      run: |
+        echo "artifact_name=${ARTIFACTNAME}"
+        echo "artifact_name=${ARTIFACTNAME}" >> $GITHUB_OUTPUT
+
     - name: Retrieve workspace
       if: ${{ inputs.action == 'retrieve' }}
       uses: actions/download-artifact@v3
       with:
-        name: ${{ inputs.artifactName || 'persisted-artifact' }}
+        name: ${{ env.ARTIFACTNAME }}
+
     - name: Extract workspace
       if: ${{ inputs.action == 'retrieve' }}
       shell: bash
-      run: |
-        ls -lah
-        tar -xf workspace.tar
+      run: tar -xzf "${TGZFILENAME}"


### PR DESCRIPTION
- Renamed 'artifactName' input to 'artifact_name'.

- The default action is 'persist'.

- Added 'retention_days' argument with a default of 3 days.

- Add 'artifact_name' output.  Also reworked the artifact name logic to include the GitHub run_id value.

- Route 'input.artifact_name' through an env variable. This helps protect against command-line injections in the 'run' statements later on.

- Exclude the '.git' folder.  There can be secrets written into the '.git/config' file.  By removing this folder, we eliminate a potential source of secrets leakage.

- Add GZIP compression.