### PR TITLE
Add 'npm config' for MyGet / GitHub Pkgs actions

### DIFF
--- a/actions/npm-config-github-packages-repository/LICENSE
+++ b/actions/npm-config-github-packages-repository/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Ritter Insurance Marketing
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/actions/npm-config-github-packages-repository/action.yml
+++ b/actions/npm-config-github-packages-repository/action.yml
@@ -1,0 +1,53 @@
+name: npm-config-github-packages-repository
+description: Configure the '.npmrc' file correctly to authenticate to GitHub Packages.
+author: ritterim
+branding:
+  icon: 'download-cloud'  
+  color: 'gray-dark'
+
+# https://dev.to/github/the-githubtoken-in-github-actions-how-it-works-change-permissions-customizations-3cgp
+
+inputs:
+
+  github_token:
+    description: A GitHub Token that can be used to access the GitHub Packages repository.
+    type: string
+    required: true
+
+  npm_scope:
+    description: The NPM 'scope' value to use.  Default is 'ritterim' as it needs to match the GitHub organization value.
+    type: string
+    required: false
+    default: ritterim
+
+runs:
+  using: "composite"
+
+  steps:
+
+    - name: Validate inputs.npm_scope
+      shell: bash
+      env: 
+        NPMSCOPE: ${{ inputs.npm_scope }}
+      run: |
+        echo "${NPMSCOPE}" | grep -E '^[a-z0-9\.-]{5,60}$'
+
+    - name: Validate inputs.github_token
+      shell: bash
+      env: 
+        GHTOKEN: ${{ inputs.github_token }}
+      run: |
+        echo "${GHTOKEN}" | grep -E '^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$'
+
+    - name: Verify current NPM config
+      shell: bash
+      run: npm config list
+
+    - name: Configure .npmrc GitHub Packages registry
+      shell: bash
+      env:
+        GHTOKEN: ${{ inputs.github_token }}
+        NPMSCOPE: ${{ inputs.npm_scope }}
+      run: |
+        npm config set "@${NPMSCOPE}:registry=https://npm.pkg.github.com"
+        npm config set "//npm.pkg.github.com/:_authToken=${GHTOKEN}"

--- a/actions/npm-config-myget-packages-repository/LICENSE
+++ b/actions/npm-config-myget-packages-repository/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Ritter Insurance Marketing
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/actions/npm-config-myget-packages-repository/action.yml
+++ b/actions/npm-config-myget-packages-repository/action.yml
@@ -1,0 +1,51 @@
+name: npm-config-myget-packages-repository
+description: Configure the '.npmrc' file correctly to authenticate to MyGet.
+author: ritterim
+branding:
+  icon: 'download-cloud'  
+  color: 'gray-dark'
+
+inputs:
+
+  myget_api_key:
+    description: The secret API key needed in order to access the MyGet API.  These are formatted as GUIDs.
+    type: string
+    required: true
+
+  npm_scope:
+    description: The NPM 'scope' value to use.  Default is 'ritterim'.
+    type: string
+    required: false
+    default: ritterim
+
+runs:
+  using: "composite"
+
+  steps:
+
+    - name: Validate inputs.npm_scope
+      shell: bash
+      env: 
+        NPMSCOPE: ${{ inputs.npm_scope }}
+      run: |
+        echo "${NPMSCOPE}" | grep -E '^[a-z0-9\.-]{5,60}$'
+
+    - name: Validate inputs.myget_api_key
+      shell: bash
+      env: 
+        MYGETAPIKEY: ${{ inputs.myget_api_key }}
+      run: |
+        echo "${MYGETAPIKEY}" | grep -E '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
+
+    - name: Verify current NPM config
+      shell: bash
+      run: npm config list
+
+    - name: Configure .npmrc MyGet registry
+      shell: bash
+      env:
+        MYGETAPIKEY: ${{ inputs.myget_api_key }}
+        NPMSCOPE: ${{ inputs.npm_scope }}
+      run: |
+        npm config set "@${NPMSCOPE}:registry=https://ritterim.myget.org/F/npm/npm/"
+        npm config set "//ritterim.myget.org/F/npm/npm/:_authToken=${MYGETAPIKEY}"


### PR DESCRIPTION
- NPM scope names must be lower-case (a-z), numbers, periods, and hyphens.  The regex used to validate this is not super strict and limits the length to 60 chars.

ref: https://github.com/npm/validate-npm-package-name

- MyGet API keys are currently GUIDs.

- GitHub token regex is from a gist.

ref: https://gist.github.com/magnetikonline/073afe7909ffdd6f10ef06a00bc3bc88