### PR TITLE
Publish NPM Package PR build/tag reusable workflows

### DIFF
--- a/.github/workflows/npm-packages-pr-build.yml
+++ b/.github/workflows/npm-packages-pr-build.yml
@@ -1,0 +1,90 @@
+name: NPM Package PR Build
+
+permissions:
+  contents: read
+  packages: read
+
+on:
+
+  workflow_call:
+
+    inputs:
+
+      always_increment_patch_version:
+        description: Do we always bump the patch value?  Even if there is no such label on the PR?
+        required: true
+        type: boolean
+
+      node_version:
+        required: false
+        type: string
+        default: '18.x'
+
+      npm_package_name:
+        required: true
+        type: string
+
+      package_filename:
+        description: Name of the 'package.json' file if not the default name.
+        required: false
+        type: string
+        default: package.json
+
+      project_directory:
+        description: Location of the package.json file for the NPM package.
+        required: false
+        type: string
+        default: ./
+
+      run_tests:
+        required: false
+        type: boolean
+        default: true
+
+    outputs:
+
+      artifact_name:
+        value: ${{ jobs.npm-pack.outputs.artifact_name }}
+
+      artifact_file_path:
+        value: ${{ jobs.npm-pack.outputs.artifact_file_path }}
+
+      version:
+        value: ${{ jobs.version.outputs.version }}
+
+jobs:
+
+  version:
+    uses: ritterim/public-github-actions/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml@384aec4638e797a402db892c9382b5ad440f5811
+    #uses: ./.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
+    with:
+      always_increment_patch_version: ${{ inputs.always_increment_patch_version }}
+      package_filename: ${{ inputs.package_filename }}
+      project_directory: ${{ inputs.project_directory }}
+      version_suffix: "-pr${{ github.event.number }}.${{ github.run_number }}"
+
+  npm-build:
+    uses: ritterim/public-github-actions/.github/workflows/npm-build.yml@2e0bccefaac35e990f13765abb37830d4ae41ccd
+    #uses: ./.github/workflows/npm-build.yml
+    with:
+      node_version: ${{ inputs.node_version }}
+      project_directory: ${{ inputs.project_directory }}
+
+  npm-test:
+    uses: ritterim/public-github-actions/.github/workflows/npm-test.yml@2e0bccefaac35e990f13765abb37830d4ae41ccd
+    #uses: ./.github/workflows/npm-test.yml
+    needs: [ npm-build ]
+    with:
+      persisted_workspace_artifact_name: ${{ needs.npm-build.outputs.persisted_workspace_artifact_name }}
+      project_directory: ${{ needs.npm-build.outputs.project_directory }}
+      run_tests: ${{ inputs.run_tests }}
+
+  npm-pack:
+    uses: ritterim/public-github-actions/.github/workflows/npm-pack.yml@2e0bccefaac35e990f13765abb37830d4ae41ccd
+    #uses: ./.github/workflows/npm-pack.yml
+    needs: [ npm-build, npm-test, version ]
+    with:
+      npm_package_name: ${{ inputs.npm_package_name }}
+      persisted_workspace_artifact_name: ${{ needs.npm-build.outputs.persisted_workspace_artifact_name }}
+      project_directory: ${{ needs.npm-build.outputs.project_directory }}
+      version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/npm-packages-pr-create-tag.yml
+++ b/.github/workflows/npm-packages-pr-create-tag.yml
@@ -1,0 +1,107 @@
+name: NPM Package PR Tag
+
+# Runs 'npm version' to create a commit and tag in the repo.
+
+permissions:
+  contents: read # later on we use a GH App to generate the token needed to push (and bypass a Ruleset that protects the default branch)
+  id-token: write
+
+on:
+
+  workflow_call:
+
+    inputs:
+
+      always_increment_patch_version:
+        description: Do we always bump the patch value?  Even if there is no such label on the PR?
+        required: true
+        type: boolean
+
+      gh_app_id:
+        description: The GitHub Application ID.
+        type: string
+        required: true
+
+      node_version:
+        required: false
+        type: string
+        default: '18.x'
+
+      npm_package_name:
+        required: true
+        type: string
+
+      package_filename:
+        description: Name of the 'package.json' file if not the default name.
+        required: false
+        type: string
+        default: package.json
+
+      project_directory:
+        description: Location of the package.json file for the NPM package.
+        required: false
+        type: string
+        default: ./
+
+      run_tests:
+        required: false
+        type: boolean
+        default: true
+
+      title:
+        description: Title for the commit.
+        required: false
+        type: string
+        default: Release
+
+    secrets:
+
+      gh_actions_secret_passing_passphrase:
+        description: The random password (usually secrets.ACTIONS_SECRET_PASSING_PASSPHRASE) used to encrypt values to be passed between job steps.
+        required: true
+
+      gh_app_private_key:
+        description: The private secret generated after creation of the GitHub Application.  It is generated in the "Private keys" section of the settings page for the application.
+        required: true
+
+jobs:
+
+  version:
+    uses: ritterim/public-github-actions/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml@384aec4638e797a402db892c9382b5ad440f5811
+    #uses: ./.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
+    with:
+      always_increment_patch_version: ${{ inputs.always_increment_patch_version }}
+      package_filename: ${{ inputs.package_filename }}
+      project_directory: ${{ inputs.project_directory }}
+
+# TODO: This spot will be good for adding enhanced security checks
+# because this workflow will have access to secrets.
+
+  # If the version was incremented, we should create a new annotated tag.
+
+  generate-token:
+    uses: ritterim/public-github-actions/.github/workflows/generate-github-token-from-github-app.yml@be109fab5ac2ca0938a67a4601e3e5d7900292f7
+    #uses: ./.github/workflows/generate-github-token-from-github-app.yml
+    needs: [ version ]
+    if: |
+      needs.version.outputs.version_incremented == 'true'
+    with:
+      gh_app_id: ${{ inputs.gh_app_id }}
+    secrets:
+      gh_actions_secret_passing_passphrase: ${{ secrets.gh_actions_secret_passing_passphrase }}
+      gh_app_private_key: ${{ secrets.gh_app_private_key }}
+
+  npm-create-release-tag:
+    #uses: ritterim/github-actions/.github/workflows/npm-create-version-tag@v1.2023.803
+    uses: ./.github/workflows/npm-create-version-tag.yml
+    needs: [ generate-token, version ]
+    if: |
+      needs.version.outputs.version_incremented == 'true'
+    secrets:
+      gh_actions_secret_passing_passphrase: ${{ secrets.gh_actions_secret_passing_passphrase }}
+      gh_encrypted_token: ${{ needs.generate-token.outputs.gh_encrypted_token }}
+    with:
+      npm_package_name: ${{ inputs.npm_package_name }}
+      project_directory: ${{ inputs.project_directory }}
+      head_commit_message: ${{ github.event.workflow_run.head_commit.message }}
+      version: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
These were tested out in a private repo to verify operation.

**npm-package-pr-build.yml:**

A read-only workflow that uses no GH secrets which will calculate the version based on PR labels, then execute the 'npm run build', 'npm run tests', 'npm pack' steps.

**npm-packages-pr-create-tag.yml:**

A workflow that runs 'npm version' and increments based on PR labels.  Then creates a release tag using a GH Token from a GH App with that version.