### PR TITLE
Fix the version-number-validator for 'v' prefixes

### DIFF
--- a/actions/version-number-validator/action.yml
+++ b/actions/version-number-validator/action.yml
@@ -11,6 +11,7 @@ inputs:
     required: true
 
   allow_v_prefix:
+    description: Whether 'v' is allowed at the start of the version value.  Note that you must pass in "true" as 'true' (a lowercase string) for this to work.
     required: false
     default: false
 
@@ -29,7 +30,7 @@ runs:
 
     - name: Validate with 'v' prefix
       uses: ritterim/public-github-actions/actions/regex-validator@v1.1.0
-      if: inputs.allow_v_prefix == true
+      if: inputs.allow_v_prefix == 'true'
       with:
         value: ${{ inputs.version }}
         regex_pattern: '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
@@ -38,7 +39,7 @@ runs:
 
     - name: Validate without 'v' prefix
       uses: ritterim/public-github-actions/actions/regex-validator@v1.1.0
-      if: inputs.allow_v_prefix != true
+      if: inputs.allow_v_prefix != 'true'
       with:
         value: ${{ inputs.version }}
         regex_pattern: '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'


### PR DESCRIPTION
Composite actions do not support typing of the inputs and everything ends up as a string.  In order to allow version strings with a 'v' prefix, you must pass in the string value 'true' (lowercase).

Ref issue 2238 at https://github.com/actions/runner