### PR TITLE
Publish 'create-github-release' composite action

### DIFF
--- a/actions/create-github-release/LICENSE
+++ b/actions/create-github-release/LICENSE
@@ -1,0 +1,22 @@
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Ritter Insurance Marketing and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/actions/create-github-release/README.md
+++ b/actions/create-github-release/README.md
@@ -1,0 +1,18 @@
+# create-github-release
+
+A composite action which will create a GitHub Release using an existing tag in the GitHub repository.
+
+- [create-github-release](#create-github-release)
+- [Example](#example)
+
+# Example
+
+```
+      - name: Create GitHub Release
+        uses: ritterim/public-github-actions/create-github-release@v1.2.0
+        with:
+          github_repository: ${{ github.repository }}
+          github_token: ${{ github.token }}
+          release_title: ${{ github.event.head_commit.message }}
+          version_tag: ${{ env.GH_REF_NAME }}
+```

--- a/actions/create-github-release/action.yml
+++ b/actions/create-github-release/action.yml
@@ -1,0 +1,67 @@
+name: create-github-release
+description: Create a GitHub Release from an existing tag.
+author: RIMdev <RIMdev@RitterIM.com>
+branding:
+  icon: 'file-text'  
+  color: 'blue'
+
+inputs:
+
+  release_title:
+    description: The release title.  Limited to 75 characters.
+    required: false
+
+  github_repository:
+    description: The GitHub repository name in the format of "{org}/{name}".  Usually sourced from the "GITHUB_REPOSITORY" environment variable.
+    required: true
+
+  github_token:
+    description: A GitHub Token that has the "contents write" permission.
+    required: true
+
+  version_tag:
+    description: The version tag for the release. It should be in the format of a valid version number with a 'v' prefix.
+
+runs:
+  using: "composite"
+
+  steps:
+
+    - name: Validate inputs.github_repository
+      uses: ritterim/github-actions/github-org-repository-validator@e037bcab7aa20ccc9b93c1ac8eae43ffae50a00f
+      env:
+        GH_REPOSITORY: ${{ inputs.github_repository }}
+      with:
+        github_repository: ${{ env.GH_REPOSITORY }}
+
+    - name: Validate inputs.github_token
+      uses: ritterim/github-actions/github-token-validator@e037bcab7aa20ccc9b93c1ac8eae43ffae50a00f
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      with:
+        github_token: ${{ env.GH_TOKEN }}
+
+    - name: Validate inputs.version_tag
+      uses: ritterim/public-github-actions/actions/version-number-validator@v1.2.0
+      env:
+        VERSIONTAG: ${{ inputs.version_tag }}
+      with:
+        version: ${{ env.VERSIONTAG }}
+        allow_v_prefix: true
+
+    - name: Create GitHub Release
+      shell: bash
+      env:
+        GH_REPOSITORY: ${{ inputs.github_repository }}
+        GH_TOKEN: ${{ inputs.github_token }}
+        RELEASETITLE: ${{ inputs.release_title }}
+        VERSIONTAG: ${{ inputs.version_tag }}
+      run: |
+        RELEASETITLE=${RELEASETITLE:-Release $VERSIONTAG}
+        RELEASETITLE=$(echo "${RELEASETITLE:0:75}" | head -n 1)
+        echo "RELEASETITLE=${RELEASETITLE}"
+        gh release create "${VERSIONTAG}" \
+          --repo="${GH_REPOSITORY}" \
+          --title="${RELEASETITLE}" \
+          --verify-tag \
+          --generate-notes


### PR DESCRIPTION
A composite action which will create a GitHub Release using an existing tag in the GitHub repository.