### PR TITLE
Add input validation to 'npm publish' workflows

### DIFF
--- a/.github/workflows/npm-packages-release-on-tag.yml
+++ b/.github/workflows/npm-packages-release-on-tag.yml
@@ -115,7 +115,7 @@ jobs:
       version: ${{ needs.version.outputs.version }}
 
   npm-publish-to-github-packages:
-    uses: ritterim/public-github-actions/.github/workflows/npm-publish-to-github-packages.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-publish-to-github-packages.yml@v1.3.0
     #uses: ./.github/workflows/npm-publish-to-github-packages.yml
     if: inputs.publish_to_github == true
     needs: [ npm-pack ]
@@ -123,7 +123,7 @@ jobs:
       artifact_name: ${{ needs.npm-pack.outputs.artifact_name }}
 
   npm-publish-to-myget:
-    uses: ritterim/public-github-actions/.github/workflows/npm-publish-to-myget.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-publish-to-myget.yml@v1.3.0
     #uses: ./.github/workflows/npm-publish-to-myget.yml
     needs: [ npm-pack ]
     if: inputs.publish_to_myget == true

--- a/.github/workflows/npm-publish-to-github-packages.yml
+++ b/.github/workflows/npm-publish-to-github-packages.yml
@@ -36,9 +36,22 @@ jobs:
 
     env:
       ARTIFACTNAME: ${{ inputs.artifact_name }}
+      PROJECTDIRECTORY: ${{ inputs.project_directory }}
 
     steps:
 
+      - name: Validate inputs.artifact_name
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.2.0
+        env:
+          ARTIFACTNAME: ${{ inputs.artifact_name }}
+        with:
+          file_name: ${{ env.ARTIFACTNAME }}
+
+      - name: Validate inputs.project_directory
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.2.0
+        with:
+          path_name: ${{ env.PROJECTDIRECTORY }}
+          
       - name: Download artifact from build job
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/npm-publish-to-myget.yml
+++ b/.github/workflows/npm-publish-to-myget.yml
@@ -41,8 +41,21 @@ jobs:
           working-directory: ${{ inputs.project_directory }}
     env:
       ARTIFACTNAME: ${{ inputs.artifact_name }}
+      PROJECTDIRECTORY: ${{ inputs.project_directory }}
 
     steps:
+
+      - name: Validate inputs.artifact_name
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.2.0
+        env:
+          ARTIFACTNAME: ${{ inputs.artifact_name }}
+        with:
+          file_name: ${{ env.ARTIFACTNAME }}
+
+      - name: Validate inputs.project_directory
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.2.0
+        with:
+          path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Download artifact from build job
         uses: actions/download-artifact@v3


### PR DESCRIPTION
These were missing validation for the artifact_name and project_directory inputs.