### PR TITLE
[BREAKING] Remove project_directory publish workflow

### DIFF
--- a/.github/workflows/npm-publish-to-github-packages.yml
+++ b/.github/workflows/npm-publish-to-github-packages.yml
@@ -24,25 +24,15 @@ on:
         required: true
         type: string
 
-      project_directory:
-        description: Location of the package.json or package .tgz file.
-        required: false
-        type: string
-        default: ./
-
 jobs:
 
   publish:
     name: GitHub Packages Publish (NPM)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-          working-directory: ${{ inputs.project_directory }}
 
     env:
       ARTIFACTNAME: ${{ inputs.artifact_name }}
       ARTIFACTFILEPATH: ${{ inputs.artifact_file_path }}
-      PROJECTDIRECTORY: ${{ inputs.project_directory }}
 
     steps:
 
@@ -56,11 +46,6 @@ jobs:
         with:
           file_name: ${{ env.ARTIFACTFILEPATH }}          
 
-      - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.3.0
-        with:
-          path_name: ${{ env.PROJECTDIRECTORY }}
-          
       - name: Download artifact from build job
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/npm-publish-to-myget.yml
+++ b/.github/workflows/npm-publish-to-myget.yml
@@ -24,12 +24,6 @@ on:
         required: true
         type: string
 
-      project_directory:
-        description: Location of the package.json or package .tgz file.
-        required: false
-        type: string
-        default: ./
-
     secrets:
 
       myget_api_key:
@@ -41,13 +35,9 @@ jobs:
   publish:
     name: MyGet Publish (NPM)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-          working-directory: ${{ inputs.project_directory }}
     env:
       ARTIFACTNAME: ${{ inputs.artifact_name }}
       ARTIFACTFILEPATH: ${{ inputs.artifact_file_path }}
-      PROJECTDIRECTORY: ${{ inputs.project_directory }}
 
     steps:
 
@@ -60,11 +50,6 @@ jobs:
         uses: ritterim/public-github-actions/actions/file-name-validator@v1.3.0
         with:
           file_name: ${{ env.ARTIFACTFILEPATH }} 
-
-      - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.3.0
-        with:
-          path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Download artifact from build job
         uses: actions/download-artifact@v3

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -3,6 +3,7 @@
 ## 1.3.0 (Sep 2023)
 
 - The NPM publish workflows will now require `artifact_file_path` to be passed in instead of assuming that the filename to publish is the `artifact_name` plus a `.tgz` suffix.
+- The NPM publish workflows no longer take in `project_directory` as an input.
 
 ## 1.2.0 (Aug 30, 2023)
 


### PR DESCRIPTION
The NPM publish workflows no longer take in `project_directory` as an input.

AFAIK, the 'npm publish' command does not look at the package.json file in the current directory. But instead looks at the contents of the tar/gzip (tgz) file.