### PR TITLE
Bump versions to prepare for upcoming v1.3.0 release

### DIFF
--- a/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
+++ b/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
@@ -107,12 +107,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.3.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.3.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/extract-version-from-npm-package-json.yml
+++ b/.github/workflows/extract-version-from-npm-package-json.yml
@@ -90,12 +90,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.3.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.3.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/generate-github-token-from-github-app.yml
+++ b/.github/workflows/generate-github-token-from-github-app.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Generate GH Token from GH App
         id: generate_token
-        uses: ritterim/public-github-actions/forks/github-app-token@v1.2.0
+        uses: ritterim/public-github-actions/forks/github-app-token@v1.3.0
         with:
           app_id: ${{ inputs.gh_app_id }}
           private_key: ${{ secrets.gh_app_private_key }}

--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -69,12 +69,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.3.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.3.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
@@ -100,7 +100,7 @@ jobs:
       - run: git rev-parse --verify HEAD
 
       - name: npm-config-github-packages-repository
-        uses: ritterim/public-github-actions/actions/npm-config-github-packages-repository@v1.2.0
+        uses: ritterim/public-github-actions/actions/npm-config-github-packages-repository@v1.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -112,4 +112,4 @@ jobs:
 
       - name: Persist Workspace
         id: persist-workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.2.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.3.0

--- a/.github/workflows/npm-create-github-release-with-artifact.yml
+++ b/.github/workflows/npm-create-github-release-with-artifact.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
 
       - name: Create GitHub Release
-        uses: ritterim/public-github-actions/actions/create-github-release@v1.2.0
+        uses: ritterim/public-github-actions/actions/create-github-release@v1.3.0
         with:
           github_repository: ${{ github.repository }}
           github_token: ${{ github.token }}
@@ -44,7 +44,7 @@ jobs:
           version_tag: ${{ env.GH_REF_NAME }}
 
       - name: Attach Artifact to GitHub Release
-        uses: ritterim/public-github-actions/actions/attach-artifact-to-release@v1.2.0
+        uses: ritterim/public-github-actions/actions/attach-artifact-to-release@v1.3.0
         with:
           artifact_name: ${{ inputs.artifact_name }}
           artifact_file_path: ${{ inputs.artifact_file_path }}

--- a/.github/workflows/npm-create-version-tag.yml
+++ b/.github/workflows/npm-create-version-tag.yml
@@ -87,27 +87,27 @@ jobs:
     steps:
 
       - name: Validate inputs.npm_scope
-        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.3.0
         with:
           npm_scope: ${{ env.NPMSCOPE }}
 
       - name: Validate inputs.npm_package_name
-        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.3.0
         with:
           package_name: ${{ env.NPMPACKAGENAME }}
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.3.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.3.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.3.0
         with:
           version: ${{ env.NPMVERSION }}
 

--- a/.github/workflows/npm-pack.yml
+++ b/.github/workflows/npm-pack.yml
@@ -83,32 +83,32 @@ jobs:
     steps:
 
       - name: Validate inputs.npm_scope
-        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.3.0
         with:
           npm_scope: ${{ env.NPMSCOPE }}
 
       - name: Validate inputs.npm_package_name
-        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.3.0
         with:
           package_name: ${{ env.NPMPACKAGENAME }}
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.3.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.3.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.3.0
         with:
           version: ${{ env.NPMVERSION }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.2.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.3.0
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/npm-packages-pr-build.yml
+++ b/.github/workflows/npm-packages-pr-build.yml
@@ -57,7 +57,7 @@ on:
 jobs:
 
   version:
-    uses: ritterim/public-github-actions/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml@v1.3.0
     #uses: ./.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
     with:
       always_increment_patch_version: ${{ inputs.always_increment_patch_version }}
@@ -66,14 +66,14 @@ jobs:
       version_suffix: "-pr${{ github.event.number }}.${{ github.run_number }}"
 
   npm-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-build.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-build.yml@v1.3.0
     #uses: ./.github/workflows/npm-build.yml
     with:
       node_version: ${{ inputs.node_version }}
       project_directory: ${{ inputs.project_directory }}
 
   npm-test:
-    uses: ritterim/public-github-actions/.github/workflows/npm-test.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-test.yml@v1.3.0
     #uses: ./.github/workflows/npm-test.yml
     needs: [ npm-build ]
     with:
@@ -82,7 +82,7 @@ jobs:
       run_tests: ${{ inputs.run_tests }}
 
   npm-pack:
-    uses: ritterim/public-github-actions/.github/workflows/npm-pack.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-pack.yml@v1.3.0
     #uses: ./.github/workflows/npm-pack.yml
     needs: [ npm-build, npm-test, version ]
     with:

--- a/.github/workflows/npm-packages-pr-create-tag.yml
+++ b/.github/workflows/npm-packages-pr-create-tag.yml
@@ -78,7 +78,7 @@ jobs:
   #       run: echo "EVENTOBJECT=$EVENTOBJECT"
 
   version:
-    uses: ritterim/public-github-actions/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml@v1.3.0
     #uses: ./.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
     with:
       always_increment_patch_version: ${{ inputs.always_increment_patch_version }}
@@ -86,7 +86,7 @@ jobs:
       project_directory: ${{ inputs.project_directory }}
 
   npm-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-build.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-build.yml@v1.3.0
     #uses: ./.github/workflows/npm-build.yml
     with:
       node_version: ${{ inputs.node_version }}
@@ -96,7 +96,7 @@ jobs:
   # because this workflow will have access to secrets.
 
   npm-test:
-    uses: ritterim/public-github-actions/.github/workflows/npm-test.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-test.yml@v1.3.0
     #uses: ./.github/workflows/npm-test.yml
     needs: [ npm-build ]
     with:
@@ -105,7 +105,7 @@ jobs:
       run_tests: ${{ inputs.run_tests }}
 
   npm-pack:
-    uses: ritterim/public-github-actions/.github/workflows/npm-pack.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-pack.yml@v1.3.0
     #uses: ./.github/workflows/npm-pack.yml
     needs: [ npm-build, npm-test, version ]
     with:
@@ -117,7 +117,7 @@ jobs:
   # If the version was incremented, we should create a new annotated tag.
 
   generate-token:
-    uses: ritterim/public-github-actions/.github/workflows/generate-github-token-from-github-app.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/generate-github-token-from-github-app.yml@v1.3.0
     #uses: ./.github/workflows/generate-github-token-from-github-app.yml
     needs: [ version, npm-pack ]
     if: |
@@ -129,7 +129,7 @@ jobs:
       gh_app_private_key: ${{ secrets.gh_app_private_key }}
 
   npm-create-release-tag:
-    uses: ritterim/public-github-actions/.github/workflows/npm-create-version-tag.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-create-version-tag.yml@v1.3.0
     #uses: ./.github/workflows/npm-create-version-tag.yml
     needs: [ generate-token, version ]
     if: |

--- a/.github/workflows/npm-packages-release-on-tag.yml
+++ b/.github/workflows/npm-packages-release-on-tag.yml
@@ -74,13 +74,13 @@ on:
 jobs:
 
   verify-tag-branch:
-    uses: ritterim/public-github-actions/.github/workflows/verify-tag-is-on-allowed-branch.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/verify-tag-is-on-allowed-branch.yml@v1.3.0
     #uses: ./.github/workflows/verify-tag-is-on-allowed-branch.yml
     with:
       allowed_branches: ${{ inputs.allowed_branches }}
 
   version:
-    uses: ritterim/public-github-actions/.github/workflows/extract-version-from-npm-package-json.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/extract-version-from-npm-package-json.yml@v1.3.0
     #uses: ./.github/workflows/extract-version-from-npm-package-json.yml
     needs: [ verify-tag-branch ]
     with:
@@ -88,7 +88,7 @@ jobs:
       project_directory: ${{ inputs.project_directory }}
 
   npm-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-build.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-build.yml@v1.3.0
     #uses: ./.github/workflows/npm-build.yml
     needs: [ verify-tag-branch ]
     with:
@@ -96,7 +96,7 @@ jobs:
       project_directory: ${{ inputs.project_directory }}
 
   npm-test:
-    uses: ritterim/public-github-actions/.github/workflows/npm-test.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-test.yml@v1.3.0
     #uses: ./.github/workflows/npm-test.yml
     needs: [ npm-build ]
     with:
@@ -105,7 +105,7 @@ jobs:
       run_tests: ${{ inputs.run_tests }}
 
   npm-pack:
-    uses: ritterim/public-github-actions/.github/workflows/npm-pack.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-pack.yml@v1.3.0
     #uses: ./.github/workflows/npm-pack.yml
     needs: [ npm-build, npm-test, version ]
     with:
@@ -133,7 +133,7 @@ jobs:
       artifact_name: ${{ needs.npm-pack.outputs.artifact_name }}
 
   create-github-release:
-    uses: ritterim/public-github-actions/.github/workflows/npm-create-github-release-with-artifact.yml@v1.2.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-create-github-release-with-artifact.yml@v1.3.0
     #uses: ./.github/workflows/npm-create-github-release-with-artifact.yml
     needs: [ npm-pack ]
     with:

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.2.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.3.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
@@ -58,7 +58,7 @@ jobs:
         run: echo "The 'inputs.run_tests' value is FALSE, skipping tests!"
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.2.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.3.0
         if: inputs.run_tests == true
         with:
           action: retrieve

--- a/actions/attach-artifact-to-release/README.md
+++ b/actions/attach-artifact-to-release/README.md
@@ -9,7 +9,7 @@ Attach artifact from the workflow run to a GitHub Release.
 
 ```
       - name: Attach Artifact to GitHub Release
-        uses: ritterim/public-github-actions/attach-artifact-to-release@v1.2.0
+        uses: ritterim/public-github-actions/attach-artifact-to-release@v1.3.0
         with:
           artifact_name: ${{ inputs.artifact_name }}
           artifact_file_path: ${{ inputs.artifact_file_path }}

--- a/actions/attach-artifact-to-release/action.yml
+++ b/actions/attach-artifact-to-release/action.yml
@@ -32,14 +32,14 @@ runs:
   steps:
 
     - name: Validate inputs.artifact_name
-      uses: ritterim/public-github-actions/actions/file-name-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/file-name-validator@v1.3.0
       env:
         ARTIFACTNAME: ${{ inputs.artifact_name }}
       with:
         file_name: ${{ env.ARTIFACTNAME }}
 
     - name: Validate inputs.artifact_file_path
-      uses: ritterim/public-github-actions/actions/file-name-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/file-name-validator@v1.3.0
       env:
         ARTIFACTFILEPATH: ${{ inputs.artifact_file_path }}
       with:
@@ -60,7 +60,7 @@ runs:
         github_token: ${{ env.GH_TOKEN }}
 
     - name: Validate inputs.version_tag
-      uses: ritterim/public-github-actions/actions/version-number-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/version-number-validator@v1.3.0
       env:
         VERSIONTAG: ${{ inputs.version_tag }}
       with:

--- a/actions/create-github-release/README.md
+++ b/actions/create-github-release/README.md
@@ -9,7 +9,7 @@ A composite action which will create a GitHub Release using an existing tag in t
 
 ```
       - name: Create GitHub Release
-        uses: ritterim/public-github-actions/create-github-release@v1.2.0
+        uses: ritterim/public-github-actions/create-github-release@v1.3.0
         with:
           github_repository: ${{ github.repository }}
           github_token: ${{ github.token }}

--- a/actions/create-github-release/action.yml
+++ b/actions/create-github-release/action.yml
@@ -42,7 +42,7 @@ runs:
         github_token: ${{ env.GH_TOKEN }}
 
     - name: Validate inputs.version_tag
-      uses: ritterim/public-github-actions/actions/version-number-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/version-number-validator@v1.3.0
       env:
         VERSIONTAG: ${{ inputs.version_tag }}
       with:

--- a/actions/file-name-validator/action.yml
+++ b/actions/file-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.1.0
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.3.0
       with:
         value: ${{ inputs.file_name }}
         regex_pattern: '^[A-Za-z0-9\.\+-]{3,70}$'

--- a/actions/github-token-validator/action.yml
+++ b/actions/github-token-validator/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
 
     - name: Validate token
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.3.0
       with:
         value: ${{ inputs.token }}
         regex_pattern: '^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$'

--- a/actions/npm-config-github-packages-repository/README.md
+++ b/actions/npm-config-github-packages-repository/README.md
@@ -23,7 +23,7 @@ You must have requested `packages: read` (or `packages:write` to publish) in you
 
 ```
       - name: npm-config-github-packages-repository
-        uses: ritterim/public-github-actions/actions/npm-config-github-packages-repository@v1.2.0
+        uses: ritterim/public-github-actions/actions/npm-config-github-packages-repository@v1.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/actions/npm-config-github-packages-repository/action.yml
+++ b/actions/npm-config-github-packages-repository/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
 
     - name: Validate inputs.npm_scope
-      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.3.0
       with:
         npm_scope: ${{ inputs.npm_scope }}
 

--- a/actions/npm-config-myget-packages-repository/README.md
+++ b/actions/npm-config-myget-packages-repository/README.md
@@ -13,7 +13,7 @@ WARN: It's not designed for use outside of our organization due to the hardcoded
 
 ```
       - name: npm-config-myget-packages-repository
-        uses: ritterim/public-github-actions/actions/npm-config-myget-packages-repository@v1.2.0
+        uses: ritterim/public-github-actions/actions/npm-config-myget-packages-repository@v1.3.0
         with:
           myget_api_key: ${{ secrets.myget_api_key }}
 ```

--- a/actions/npm-config-myget-packages-repository/action.yml
+++ b/actions/npm-config-myget-packages-repository/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate inputs.npm_scope
-      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.3.0
       with:
         npm_scope: ${{ inputs.npm_scope }}
 

--- a/actions/npm-config-npmjs-org-registry/action.yml
+++ b/actions/npm-config-npmjs-org-registry/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate inputs.npm_scope
-      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.3.0
       with:
         npm_scope: ${{ inputs.npm_scope }}
 

--- a/actions/npm-package-name-validator/action.yml
+++ b/actions/npm-package-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.3.0
       with:
         value: ${{ inputs.package_name }}
         regex_pattern: '^[a-z0-9\-]{5,40}$'

--- a/actions/npm-package-scope-validator/action.yml
+++ b/actions/npm-package-scope-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.3.0
       with:
         value: ${{ inputs.npm_scope }}
         regex_pattern: '^[a-z0-9\-]{5,25}$'

--- a/actions/npmjs-access-token-validator/action.yml
+++ b/actions/npmjs-access-token-validator/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.3.0
       with:
         value: ${{ inputs.token }}
         regex_pattern: '^(npm_[A-Za-z0-9]{36})$'

--- a/actions/path-name-validator/action.yml
+++ b/actions/path-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.3.0
       with:
         value: ${{ inputs.path_name }}
         regex_pattern: '^[A-Za-z0-9\.\+\/-]{1,70}\/$'

--- a/actions/version-number-validator/action.yml
+++ b/actions/version-number-validator/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
 
     - name: Validate with 'v' prefix
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.3.0
       if: inputs.allow_v_prefix == 'true'
       with:
         value: ${{ inputs.version }}
@@ -38,7 +38,7 @@ runs:
         error_if_not_valid: ${{ inputs.error_if_not_valid }}
 
     - name: Validate without 'v' prefix
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.2.0
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.3.0
       if: inputs.allow_v_prefix != 'true'
       with:
         value: ${{ inputs.version }}


### PR DESCRIPTION
Have all of the actions/workflows start referencing the v1.3.0 release which is being tested this week.