### PR TITLE
Tweak myget_api_key description, make optional

### DIFF
--- a/.github/workflows/npm-packages-release-on-tag.yml
+++ b/.github/workflows/npm-packages-release-on-tag.yml
@@ -68,8 +68,8 @@ on:
     secrets:
 
       myget_api_key:
-        description: Please pass in the 'secrets.MYGET_DEPLOY_API_KEY_SECRET' value.
-        required: true
+        description: The secret API key needed in order to access the MyGet API.  These are formatted as GUIDs.
+        required: false
 
 jobs:
 

--- a/.github/workflows/npm-publish-to-myget.yml
+++ b/.github/workflows/npm-publish-to-myget.yml
@@ -27,7 +27,7 @@ on:
     secrets:
 
       myget_api_key:
-        description: Please pass in the 'secrets.MYGET_DEPLOY_API_KEY_SECRET' value.
+        description: The secret API key needed in order to access the MyGet API.  These are formatted as GUIDs.
         required: true
 
 jobs:


### PR DESCRIPTION
If the caller is not specifying that they want to publish to MyGet then they don't need to specify the API key. We do checks inside the called actions/workflows to prevent an empty key from being accepted.