### PR TITLE
Switch to use the public github-token-validator

### DIFF
--- a/actions/attach-artifact-to-release/action.yml
+++ b/actions/attach-artifact-to-release/action.yml
@@ -53,11 +53,9 @@ runs:
         github_repository: ${{ env.GH_REPOSITORY }}
 
     - name: Validate inputs.github_token
-      uses: ritterim/github-actions/github-token-validator@e037bcab7aa20ccc9b93c1ac8eae43ffae50a00f
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
+      uses: ritterim/github-actions/actions/github-token-validator@v1.3.0
       with:
-        github_token: ${{ env.GH_TOKEN }}
+        token: ${{ inputs.github_token }}
 
     - name: Validate inputs.version_tag
       uses: ritterim/public-github-actions/actions/version-number-validator@v1.3.0

--- a/actions/create-github-release/action.yml
+++ b/actions/create-github-release/action.yml
@@ -35,11 +35,9 @@ runs:
         github_repository: ${{ env.GH_REPOSITORY }}
 
     - name: Validate inputs.github_token
-      uses: ritterim/github-actions/github-token-validator@e037bcab7aa20ccc9b93c1ac8eae43ffae50a00f
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
+      uses: ritterim/github-actions/actions/github-token-validator@v1.3.0
       with:
-        github_token: ${{ env.GH_TOKEN }}
+        token: ${{ inputs.github_token }}
 
     - name: Validate inputs.version_tag
       uses: ritterim/public-github-actions/actions/version-number-validator@v1.3.0


### PR DESCRIPTION
Private repositories can't be called from public repos (or actions running in public repos).