### PR TITLE
Add github-org-repository-validator action

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ These actions help configure your `.npmrc` file to authenticate against differen
 Actions which can be used to validate input values to workflows against RegEx patterns.  While not guaranteed, these can help reduce the risk of command-line injection vulnerabilities or guard against simple mistakes.
 
 - [file-name-validator](actions/file-name-validator/)
+- [github-org-repository-validator](actions/github-org-repository-validator/)
 - [github-token-validator](actions/github-token-validator/)
 - [npm-package-name-validator](actions/npm-package-name-validator/)
 - [npm-package-scope-validator](actions/npm-package-scope-validator/)

--- a/actions/attach-artifact-to-release/action.yml
+++ b/actions/attach-artifact-to-release/action.yml
@@ -46,11 +46,9 @@ runs:
         file_name: ${{ env.ARTIFACTFILEPATH }}
 
     - name: Validate inputs.github_repository
-      uses: ritterim/github-actions/github-org-repository-validator@e037bcab7aa20ccc9b93c1ac8eae43ffae50a00f
-      env:
-        GH_REPOSITORY: ${{ inputs.github_repository }}
+      uses: ritterim/public-github-actions/github-org-repository-validator@v1.4.0
       with:
-        github_repository: ${{ env.GH_REPOSITORY }}
+        github_repository: ${{ inputs.github_repository }}
 
     - name: Validate inputs.github_token
       uses: ritterim/github-actions/github-token-validator@e037bcab7aa20ccc9b93c1ac8eae43ffae50a00f

--- a/actions/create-github-release/action.yml
+++ b/actions/create-github-release/action.yml
@@ -28,11 +28,9 @@ runs:
   steps:
 
     - name: Validate inputs.github_repository
-      uses: ritterim/github-actions/github-org-repository-validator@e037bcab7aa20ccc9b93c1ac8eae43ffae50a00f
-      env:
-        GH_REPOSITORY: ${{ inputs.github_repository }}
+      uses: ritterim/public-github-actions/github-org-repository-validator@v1.4.0
       with:
-        github_repository: ${{ env.GH_REPOSITORY }}
+        github_repository: ${{ inputs.github_repository }}
 
     - name: Validate inputs.github_token
       uses: ritterim/github-actions/github-token-validator@e037bcab7aa20ccc9b93c1ac8eae43ffae50a00f

--- a/actions/github-org-repository-validator/LICENSE
+++ b/actions/github-org-repository-validator/LICENSE
@@ -1,0 +1,22 @@
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Ritter Insurance Marketing and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/actions/github-org-repository-validator/action.yml
+++ b/actions/github-org-repository-validator/action.yml
@@ -1,0 +1,32 @@
+name: github-org-repository-validator
+description: Validate that the value looks like a GitHub repository in the format of "{org}/{name}".  It only allows alphanumeric names plus hyphens.
+author: RIMdev <RIMdev@RitterIM.com>
+branding:
+  icon: 'check-square'  
+  color: 'blue'
+
+inputs:
+
+  github_repository:
+    required: true
+
+  required:
+    required: false
+    default: true
+
+  error_if_not_valid:
+    required: false
+    default: true
+
+runs:
+  using: "composite"
+
+  steps:
+
+    - name: Validate
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.2.0
+      with:
+        value: ${{ inputs.github_repository }}
+        regex_pattern: '^[a-zA-Z0-9-]{1,25}\/[a-zA-Z0-9-]{1,50}$'
+        required: ${{ inputs.required }}
+        error_if_not_valid: ${{ inputs.error_if_not_valid }}


### PR DESCRIPTION
Validate that the value looks like a GitHub repository in the format of "{org}/{name}".  It only allows
alphanumeric names plus hyphens.