### PR TITLE
Fix bug in file-path-name-validator

### DIFF
--- a/actions/file-path-name-validator/action.yml
+++ b/actions/file-path-name-validator/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Validate
       uses: ritterim/public-github-actions/actions/regex-validator@v1.4.0
       with:
-        value: ${{ inputs.file_name }}
+        value: ${{ inputs.file_path_name }}
         regex_pattern: '^[A-Za-z0-9\.\+\/-]{2,90}$'
         required: ${{ inputs.required }}
         error_if_not_valid: ${{ inputs.error_if_not_valid }}


### PR DESCRIPTION
The file_path_name input was not being passed to the regex validator.