### PR TITLE
regex-validator: Import from '@jest/globals', add version regex tests

### DIFF
--- a/actions/regex-validator/tests/validate-input.test.ts
+++ b/actions/regex-validator/tests/validate-input.test.ts
@@ -1,7 +1,7 @@
-import { describe } from 'node:test';
+import {describe, expect, it} from '@jest/globals';
 import { ValidateInput } from '../src/validate';
 
-const regexExpression = "^[A-Za-z0-9 \.,]{1,80}$";
+const regexExpression = "^[A-Za-z0-9 .,]{1,80}$";
 const input = 'cdbbdbsbz';
 
 describe('Validate Input Required False', () => {
@@ -9,7 +9,6 @@ describe('Validate Input Required False', () => {
         var result = ValidateInput(input, regexExpression, false);
         expect(result.isValid).toBe(true)
     });
-
 
     it('returns false result if input is empty string', () => {
         const input = '';
@@ -65,4 +64,21 @@ describe('Error Message', () => {
         expect(result.isValid).toBe(false);
         expect(typeof result.error).toBe('string');
     })
+})
+
+describe('ValidateInput: Version RegEx', () => {
+    const versionRegex = String.raw`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9A-Za-z-][0-9A-Za-z-]*)(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$`
+    const cases = [
+        {value: '0.0.1-alpha3', expected: true},
+        {value: '0.900.85948-alpha3.2+abcdef', expected: true},
+        {value: '1.2.0', expected: true},
+        {value: '1.A.0', expected: false}
+    ];
+    it.each(cases)(
+        "Case: '$value' returns $expected",
+        ({value, expected}) => {
+          let result = ValidateInput(value, versionRegex, true);
+          expect(result.isMatched).toEqual(expected);
+        }
+      );
 })

--- a/actions/regex-validator/tsconfig.json
+++ b/actions/regex-validator/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../tsconfig.json",
   "compilerOptions": {
     "target": "ES2022",
     "types": ["node", "jest"],


### PR DESCRIPTION
Switch from node:test to jest/globals.  Add some tests around the version string regex which shows how to setup a set of test cases.

```
 PASS  tests/validate-input.test.ts
  Validate Input Required False
    ✓ returns valid if required is false (1 ms)
    ✓ returns false result if input is empty string (1 ms)
    ✓ returns false result if input is empty string
    ✓ returns invalid if require and input are empty
  Validate Input Required True
    ✓ matched returns true result
    ✓ matched returns true result with case insensitive (1 ms)
    ✓ returns result string
  Error Message
    ✓ displays error
  ValidateInput: Version RegEx
    ✓ Case: '0.0.1-alpha3' returns true (1 ms)
    ✓ Case: '0.900.85948-alpha3.2+abcdef' returns true
    ✓ Case: '1.2.0' returns true
    ✓ Case: '1.A.0' returns false (1 ms)

Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
```