### PR TITLE
fix: job steps which need to run in sub-directory

### DIFF
--- a/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
+++ b/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
@@ -116,16 +116,17 @@ jobs:
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
-      - name: Checkout Project
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
-
       - name: git ref debug information
+        working-directory: ./
         run: |
           echo "github.base_ref=${{ github.base_ref }}"
           echo "github.head_ref=${{ github.head_ref }}"
           echo "github.ref=${{ github.ref }}"
+
+      - name: Checkout Project
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
 
       - name: Examine PR labels
         env:

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -83,6 +83,7 @@ jobs:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: git ref debug information
+        working-directory: ./
         run: |
           echo "github.base_ref=${{ github.base_ref }}"
           echo "github.head_ref=${{ github.head_ref }}"

--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -79,6 +79,7 @@ jobs:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: git ref debug information
+        working-directory: ./
         run: |
           echo "github.base_ref=${{ github.base_ref }}"
           echo "github.head_ref=${{ github.head_ref }}"

--- a/.github/workflows/npm-pack.yml
+++ b/.github/workflows/npm-pack.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-          working-directory: ${{ inputs.project_directory }}
+        working-directory: ${{ inputs.project_directory }}
 
     outputs:
       artifact_name: ${{ steps.set-outputs.outputs.artifact_name }}

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -55,6 +55,7 @@ jobs:
 
       - name: Bypass Tests
         if: inputs.run_tests != true
+        working-directory: ./
         run: echo "The 'inputs.run_tests' value is FALSE, skipping tests!"
 
       - name: Restore Workspace

--- a/.github/workflows/verify-tag-is-on-allowed-branch.yml
+++ b/.github/workflows/verify-tag-is-on-allowed-branch.yml
@@ -45,6 +45,7 @@ jobs:
     steps:
 
       - name: git ref debug information
+        working-directory: ./
         run: |
           echo "github.base_ref=${{ github.base_ref }}"
           echo "github.head_ref=${{ github.head_ref }}"


### PR DESCRIPTION
In situations where the job specifies a default working-directory for a run statement, where that directory only exists after checkout; we need to reorder the steps.

The alternative choice would be to specify a "./" working-directory for the steps that don't have to be run from a subdirectory.  This is good for those debug statements examining the github.ref value prior to doing the checkout.