### PR TITLE
Switch to using npm-build-test-public.yml for tests

### DIFF
--- a/.github/workflows/__pr-build-actions-regex-validator.yml
+++ b/.github/workflows/__pr-build-actions-regex-validator.yml
@@ -2,7 +2,6 @@ name: PR Build (actions/regex-validator)
 
 permissions:
   contents: read
-  packages: read
 
 on:
   pull_request:
@@ -10,13 +9,13 @@ on:
       - master
     paths:
       - .github/workflows/__pr-build-actions-regex-validator.yml
+      - .github/workflows/npm-build-test-public.yml
       - actions/regex-validator/**
 
 jobs:
 
   pr-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-build-test.yml@v1.6.0
-    #uses: ./.github/workflows/npm-packages-pr-build.yml
+    uses: ritterim/public-github-actions/.github/workflows/npm-build-test-public.yml@v1.6.0
     with:
       project_directory: actions/regex-validator/
       run_tests: true


### PR DESCRIPTION
The actions/regex-validator does not pull from our private GitHub packages.  Therefore there is no need to give it 'packages: read' or use a workflow that requires that.