### PR TITLE
Add calculate-version-from-txt-using-github-run-id action

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ GitHub Actions authored by RIMdev.
 ## GitHub
 
 - [attach-artifact-to-release](actions/attach-artifact-to-release/)
+- [calculate-version-from-txt-using-github-run-id](actions/calculate-version-from-txt-using-github-run-id/)
 - [create-github-release](actions/create-github-release/)
 
 ## NPM Registry Configuration

--- a/actions/calculate-version-from-txt-using-github-run-id/LICENSE
+++ b/actions/calculate-version-from-txt-using-github-run-id/LICENSE
@@ -1,0 +1,22 @@
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Ritter Insurance Marketing and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/actions/calculate-version-from-txt-using-github-run-id/README.md
+++ b/actions/calculate-version-from-txt-using-github-run-id/README.md
@@ -1,0 +1,49 @@
+# calculate-version-from-txt-using-github-run-id
+
+A composite action which will calculate the version number for the build using a `version.txt` file for the major/minor values and the `github.run_id` value to calculate the patch value.
+
+Read on for why you may want to use a different version calculation / workflow.
+
+- [calculate-version-from-txt-using-github-run-id](#calculate-version-from-txt-using-github-run-id)
+- [Patch Number Calculation](#patch-number-calculation)
+- [Example](#example)
+
+# Patch Number Calculation
+
+The goal of the patch number calculation is to automatically assign a patch value to the SemVer at the start of the build.  This will make every build automatically get an unique version without having to constantly edit a `version.txt` file on every PR.
+
+The problem we run into under GitHub Actions is that there is no monotonically increasing value at the repository level (or even organization level).  While there is the `github.run_number`; it is a unique counter per workflow in the repository and not overall.
+
+So the next best solution is to simply use the `github.run` ID value.  However this value has some problems:
+
+- Some build systems not allowing patch values over 65535 (unsigned 16-bit integer).
+- The value is global for all of GitHub.
+- It increments at a rate of about 10 million per day.
+
+Given those limitations, we have setup a calculation that gives you a **new patch value about every 14-16 minutes**.  For many projects, you're probably not doing a release that frequently.
+
+Your 'baseline' value should be some round number that is lower then the current global GitHub run ID value.  Such as `6100000000`.
+
+Our current estimate is that the values will go from 1 to 65535 in the span of about 650 days.  If you don't have to worry about the 16-bit limit, you will never need to adjust your baseline.  If you do need to worry about it, consider bumping your baseline value every time you bump the major/minor values in the `version.txt` file.
+
+# Example
+
+This is an example of an internal build that tacks on the `github.run_number` which helps make frequent dev builds unique.  For a public release, you'd probably want to omit the 'version_suffix' input or set it to an empty string.
+
+Note that you *must* have a `version.txt` file in the root of the repository with your major/minor value.
+
+```
+    steps:
+
+      - name: Checkout Project
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Calculate Version
+        id: version
+        uses: ritterim/public-github-actions/actions/calculate-version-from-txt-using-github-run-id@v1.7.0
+        with:
+          version_suffix: "-alpha${{ github.run_number }}"
+          github_run_id_baseline: 6100000000
+```

--- a/actions/calculate-version-from-txt-using-github-run-id/action.yml
+++ b/actions/calculate-version-from-txt-using-github-run-id/action.yml
@@ -1,0 +1,143 @@
+name: Calculate Version
+description: Calculates the version using a version.txt file and GitHub "github.run_id" value.
+
+# Calculates the version using a version.txt file and GitHub "github.run_id" value.
+# This will increment the patch value roughly every 15 minutes.
+
+# The github.run_id is a value like 5268670002 or 5660026243.  As of mid-2023
+# the value increases by about 9-10 million per day.  Some build sytems limit
+# the patch value to 65535 which results in it rolling over about every 650 days
+# unless you bump the minor version and then change your 'github_run_id_baseline'.
+
+# The main advantage of doing it this way is that every build (if infrequent)
+# will automatically get a unique SemVer patch value.
+
+inputs:
+
+  version_suffix:
+    description: The version suffix (e.g. "-pr123" or "-alpha1342") for non-release builds.
+    required: false
+    type: string
+
+  github_run_id_baseline:
+    description: The zero point for calculating the patch value from the 'github.run_id' value.  Currently a ten digit integer value, but we'll allow up to twelve digits.
+    required: true
+    type: string
+
+outputs:
+
+  short_git_hash:
+    description: The first 8 digits of the full git hash.
+    value: ${{ steps.calculate.outputs.short_git_hash }}
+
+  git_hash:
+    description: The full git hash.
+    value: ${{ steps.calculate.outputs.git_hash }}
+
+  major_minor_version:
+    description: The major/minor version, e.g. "10.1".
+    value: ${{ steps.calculate.outputs.major_minor_version }}
+
+  patch_version:
+    description: The value for the patch position in the version number.
+    value: ${{ steps.calculate.outputs.patch_version }}
+
+  version:
+    description: The version number to be used in most cases.  Usually "10.1.2750" or "10.1.2750-SUFFIX".
+    value: ${{ steps.calculate.outputs.version }}
+
+  informational_version:
+    description: The informational version number which includes additional information after a plus sign.  Usually followed by the git short hash, e.g. "10.1.2750+abcd1234".
+    value: ${{ steps.calculate.outputs.informational_version }}
+
+  version_suffix:
+    description: The version suffix (e.g. "-pr123" or "-alpha1342") which was passed in.
+    value: ${{ steps.calculate.outputs.version_suffix }}
+
+runs:
+  using: "composite"
+
+  steps:
+
+    - run: cat version.txt
+      shell: bash
+
+    - name: Validate inputs.github_run_id_baseline
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.5.0
+      with:
+        value: ${{ inputs.github_run_id_baseline }}
+        regex_pattern: '^[0-9]{10,12}$'    
+
+    - name: Validate inputs.github_run_id_baseline against github.run_id
+      shell: bash
+      env:
+        GHRUNID: ${{ github.run_id }}
+        BASELINE: ${{ inputs.github_run_id_baseline }}
+      run: |
+        GHRUNID=$(("${GHRUNID}"))
+        BASELINE=$(("${BASELINE}"))
+        echo "GHRUNID=${GHRUNID}"
+        echo "BASELINE=${BASELINE}"
+        if (( "${BASELINE}" < 5200000000 || "${BASELINE}" > 10000000000 )); then
+          echo "The 'inputs.github_run_id_baseline' value was not within the acceptable range."
+          exit 1
+        fi
+        if (( "${BASELINE}" > "${GHRUNID}" )); then
+          echo "The 'inputs.github_run_id_baseline' value (${BASELINE}) is larger than the current github.run_id (${GHRUNID}) value!"
+          exit 1
+        fi
+
+    # Pull the major.minor values out of the first non-empty line in the version.txt file.
+    # Any patch values will be ignored.
+    # We then calculate the patch version and short git hash.
+
+    # https://stackoverflow.com/a/1188376
+    # The github.run_id is currently a 10-digit value, way over the 65535 value limit for major/minor/patch in .NET/Windows.
+    # So we need to drop the digits to get from 5199779292 down to a value like 102.
+    # This calculation may need to be reconsidered every few months.  We chose a starting value of 5200000000.
+    # 2023-06-05: 5177692715
+    # 2023-06-14: 5268670002 (+90977287 or +10108587 per day), we're already up to 1/10th of our limit after just 7 days
+    # So the 3rd digit increases by +1 per day.  That means we hit 65,000 after only 65-70 days, we need 650-700 days.
+    # See: https://github.com/ritterim/devops-notes for the full details.
+
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # Note that GITHUB_SHA for this event is the last merge commit of the pull request merge branch.
+    # If you want to get the commit ID for the last commit to the head branch of the pull request,
+    # use github.event.pull_request.head.sha instead.
+
+    - name: Set Version Variables
+      id: calculate
+      shell: bash
+      env:
+        PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        GH_RUN_ID: ${{ github.run_id }}
+        GH_RUN_ID_BASELINE: ${{ inputs.github_run_id_baseline }}
+        GH_VER_SUFFIX: ${{ inputs.version_suffix }}
+
+      run: |
+        GH_RUN_ID=$(("${GH_RUN_ID}"))
+        GH_RUN_ID_BASELINE=$(("${GH_RUN_ID_BASELINE}"))
+        VER=$(grep -Eo '^[0-9]{1,5}\.[0-9]{1,5}' version.txt | head -n1)
+        PATCH_VER=$(((${GH_RUN_ID} - ${GH_RUN_ID_BASELINE}) / 100000))
+        PULL_REQUEST_HEAD_SHORT_SHA=$(echo ${PULL_REQUEST_HEAD_SHA} | cut -c1-8)
+        GH_SHA_CALC="${PULL_REQUEST_HEAD_SHA:-${GITHUB_SHA:-ERROR}}"
+        GH_SHORT_SHA_CALC=$(echo ${GH_SHA_CALC} | cut -c1-8)
+        GH_VER_PATCH_SUFFIX="$VER.$PATCH_VER$GH_VER_SUFFIX"
+        echo "git_hash=$GH_SHA_CALC" >> $GITHUB_OUTPUT
+        echo "short_git_hash=$GH_SHORT_SHA_CALC" >> $GITHUB_OUTPUT
+        echo "version_suffix=$GH_VER_SUFFIX" >> $GITHUB_OUTPUT
+        echo "major_minor_version=$VER" >> $GITHUB_OUTPUT
+        echo "patch_version=$PATCH_VER" >> $GITHUB_OUTPUT
+        echo "version=$GH_VER_PATCH_SUFFIX" >> $GITHUB_OUTPUT
+        echo "informational_version=$GH_VER_PATCH_SUFFIX+$GH_SHORT_SHA_CALC" >> $GITHUB_OUTPUT
+
+    - name: Echo Version Output Variables
+      shell: bash
+      run: |
+        echo "informational_version=${{ steps.calculate.outputs.informational_version }}"
+        echo "major_minor_version=${{ steps.calculate.outputs.major_minor_version }}"
+        echo "patch_version=${{ steps.calculate.outputs.patch_version }}"
+        echo "version_suffix=${{ steps.calculate.outputs.version_suffix }}"
+        echo "version=${{ steps.calculate.outputs.version }}"
+        echo "git_hash=${{ steps.calculate.outputs.git_hash }}" 
+        echo "short_git_hash=${{ steps.calculate.outputs.short_git_hash }}" 


### PR DESCRIPTION
Calculates the version using a `version.txt` file and GitHub "`github.run_id`" value. This will increment the patch value roughly every 15 minutes.