### PR TITLE
Regex | Returns Results of Test Method 

### DIFF
--- a/actions/regex-validator/src/validate.ts
+++ b/actions/regex-validator/src/validate.ts
@@ -46,13 +46,21 @@ function matchRegexPattern (
     regexPattern: string,
     caseSensitive: boolean
     ): boolean {
+    const errorMessage = "The input was not valid";
+
     try {
         var caseSensitiveFlag = caseSensitive ? "" : "i";
         var re = new RegExp(regexPattern, caseSensitiveFlag);
         var regexResult = re.test(input)
+
+        if(!regexResult) {
+            result.error = errorMessage;
+            return false;
+        }
+
         return regexResult;
     } catch (error: any) {
-        result.error = "The input was not valid."
+        result.error = errorMessage;
         return false;
     }
 }

--- a/actions/regex-validator/tests/validate-input.test.ts
+++ b/actions/regex-validator/tests/validate-input.test.ts
@@ -58,10 +58,18 @@ describe('Validate Input Required True', () => {
 
 describe('Error Message', () => {
     it('displays error', () => {
-        const regexExpression = String.raw`!\\\\\\^!^!^(0|[1-9]\d*)$?`
+        const regexExpression = String.raw`!\\\\\\^!^!^(0|[1-9]\d*)$?`;
         var result = ValidateInput('cdbbdbsbz', regexExpression, true, true);
 
         expect(result.isValid).toBe(false);
+        expect(typeof result.error).toBe('string');
+    })
+
+    it('return error when regex is valid but doesn\'t pass test method', () => {
+        const regexExpression = String.raw`^[0-9]{10,12}$`;
+        var result = ValidateInput('not a number', regexExpression, true, true);
+
+        expect(result.isMatched).toBe(false);
         expect(typeof result.error).toBe('string');
     })
 })


### PR DESCRIPTION
## Issue https://github.com/ritterim/infrastructure/issues/1931
Before we were only returning an error message if the `re.test` broke. This adds logic based on the results of the `re.test` method. If the input doesn't match the regex expression passed in then it will return `false` with the generic error message.