### PR TITLE
Add a random suffix for persisted workspace name

### DIFF
--- a/forks/persist-workspace/action.yml
+++ b/forks/persist-workspace/action.yml
@@ -56,7 +56,8 @@ runs:
         INPUTARTIFACTNAME: ${{ inputs.artifact_name }}
       run: |
         GITHUBRUNID=${{ github.run_id }}
-        ARTIFACTNAME=${INPUTARTIFACTNAME:-persisted-workspace-$GITHUBRUNID}
+        RANDOMSUFFIX=$(dd if=/dev/urandom bs=12 count=1 status=none | base64 | tr -dc A-Za-z0-9)
+        ARTIFACTNAME=${INPUTARTIFACTNAME:-persisted-workspace-$GITHUBRUNID-$RANDOMSUFFIX}
         echo "ARTIFACTNAME=${ARTIFACTNAME}"
         echo "ARTIFACTNAME=${ARTIFACTNAME}" >> $GITHUB_ENV
 


### PR DESCRIPTION
There are times when we need to juggle two or more persisted workspaces, such as in a repository with multiple build jobs.  This adds randomized suffix (of about 96 bits) to the artifact name.