### PR TITLE
Remove the DLL check for 'dotnet publish'

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -147,10 +147,7 @@ jobs:
 
       - run: cat app/githash.txt
 
-      - run: ls -l 'app'
-
-      # There must be at least one .dll file in the app folder for success
-      - run: ls -lt app/*.dll
+      - run: ls -lR 'app'
 
       - run: mkdir -p 'output'
 


### PR DESCRIPTION
When building Azure Functions, the DLLs get put down in a 'bin/' folder instead of at the root of the app.

We'll also add the recursive option to the 'ls -l app/' step.