### PR TITLE
The NuGet cache key should respect the project dir

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -55,6 +55,7 @@ jobs:
 
     env:
       CONFIGURATION: ${{ inputs.configuration }}
+      NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
       PROJECTDIRECTORY: ${{ inputs.project_directory }}
 
     steps:
@@ -94,7 +95,7 @@ jobs:
       - name: Setup ~/.nuget/packages cache
         uses: actions/cache@v3
         with:
-          key: nuget-packages-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |
             ~/.nuget/packages
 

--- a/.github/workflows/dotnet-npm-build.yml
+++ b/.github/workflows/dotnet-npm-build.yml
@@ -89,6 +89,7 @@ jobs:
       CONFIGURATION: ${{ inputs.configuration }}
       NPMPACKAGEJSONFILENAME: ${{ inputs.npm_package_json_filename }}
       NPMPROJECTDIRECTORY: ${{ inputs.npm_project_directory }}
+      NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
       PROJECTDIRECTORY: ${{ inputs.project_directory }}
 
     steps:
@@ -138,7 +139,7 @@ jobs:
       - name: Setup ~/.nuget/packages cache
         uses: actions/cache@v3
         with:
-          key: nuget-packages-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |
             ~/.nuget/packages
 

--- a/.github/workflows/dotnet-npm-test.yml
+++ b/.github/workflows/dotnet-npm-test.yml
@@ -119,6 +119,7 @@ jobs:
       CONFIGURATION: ${{ inputs.configuration }}
       NPMPACKAGEJSONFILENAME: ${{ inputs.npm_package_json_filename }}
       NPMPROJECTDIRECTORY: ${{ inputs.npm_project_directory }}
+      NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
       PROJECTDIRECTORY: ${{ inputs.project_directory }}
       RIMDEVTESTS__ELASTICSEARCH__PORT: ${{ inputs.docker_elasticsearch_http_port }}
       RIMDEVTESTS__ELASTICSEARCH__TRANSPORTPORT: ${{ inputs.docker_elasticsearch_transport_port }}
@@ -210,7 +211,7 @@ jobs:
       - name: Setup ~/.nuget/packages cache
         uses: actions/cache@v3
         with:
-          key: nuget-packages-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |
             ~/.nuget/packages
 

--- a/.github/workflows/dotnet-pack.yml
+++ b/.github/workflows/dotnet-pack.yml
@@ -61,6 +61,7 @@ jobs:
     env:
       ARTIFACTNAME: ${{ inputs.artifact_name }}
       CONFIGURATION: ${{ inputs.configuration }}
+      NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
       PROJECTDIRECTORY: ${{ inputs.project_directory }}
       INFORMATIONALVERSION: ${{ inputs.informational_version }}
       VERSION: ${{ inputs.version }}
@@ -111,7 +112,7 @@ jobs:
       - name: Setup ~/.nuget/packages cache
         uses: actions/cache@v3
         with:
-          key: nuget-packages-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |
             ~/.nuget/packages
 

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -68,6 +68,7 @@ jobs:
     env:
       ARTIFACTNAME: ${{ inputs.artifact_name }}
       CONFIGURATION: ${{ inputs.configuration }}
+      NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
       PROJECTDIRECTORY: ${{ inputs.project_directory }}
       INFORMATIONALVERSION: ${{ inputs.informational_version }}
       VERSION: ${{ inputs.version }}
@@ -124,7 +125,7 @@ jobs:
       - name: Setup ~/.nuget/packages cache
         uses: actions/cache@v3
         with:
-          key: nuget-packages-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |
             ~/.nuget/packages
 

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -99,6 +99,7 @@ jobs:
     env:
       ARTIFACTNAME: ${{ inputs.artifact_name }}
       CONFIGURATION: ${{ inputs.configuration }}
+      NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
       PROJECTDIRECTORY: ${{ inputs.project_directory }}
       RIMDEVTESTS__ELASTICSEARCH__PORT: ${{ inputs.docker_elasticsearch_http_port }}
       RIMDEVTESTS__ELASTICSEARCH__TRANSPORTPORT: ${{ inputs.docker_elasticsearch_transport_port }}
@@ -188,7 +189,7 @@ jobs:
         uses: actions/cache@v3
         if: inputs.run_tests == true
         with:
-          key: nuget-packages-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |
             ~/.nuget/packages
 


### PR DESCRIPTION
In situations where we have multiple C# solutions, the NuGet cache key should also be different by path.
Instead of looking at all csproj files in the repository, we only want to look at csproj files at or below the non-root project directory.