### PR TITLE
Add artifact_retention_days to pack/publish/test

### DIFF
--- a/.github/workflows/dotnet-npm-test.yml
+++ b/.github/workflows/dotnet-npm-test.yml
@@ -19,6 +19,11 @@ on:
         required: true
         type: string
 
+      artifact_retention_days:
+        required: false
+        type: number
+        default: 90
+
       configuration:
         required: true
         type: string
@@ -251,4 +256,5 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: "${{ inputs.project_directory }}**/*.trx"
+          retention-days: ${{ inputs.artifact_retention_days }}
           if-no-files-found: error

--- a/.github/workflows/dotnet-pack.yml
+++ b/.github/workflows/dotnet-pack.yml
@@ -16,6 +16,11 @@ on:
         required: true
         type: string
 
+      artifact_retention_days:
+        required: false
+        type: number
+        default: 90
+
       configuration:
         required: false
         type: string
@@ -136,4 +141,5 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: "${{ inputs.project_directory }}artifacts/*.*nupkg"
+          retention-days: ${{ inputs.artifact_retention_days }}
           if-no-files-found: error

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -16,6 +16,11 @@ on:
         required: true
         type: string
 
+      artifact_retention_days:
+        required: false
+        type: number
+        default: 90
+
       configuration:
         required: false
         type: string
@@ -170,4 +175,5 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: "${{ inputs.project_directory }}output/${{ env.ZIPFILENAME }}"
+          retention-days: ${{ inputs.artifact_retention_days }}
           if-no-files-found: error

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -14,6 +14,11 @@ on:
         required: true
         type: string
 
+      artifact_retention_days:
+        required: false
+        type: number
+        default: 90
+
       configuration:
         required: true
         type: string
@@ -215,4 +220,5 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: "${{ inputs.project_directory }}**/*.trx"
+          retention-days: ${{ inputs.artifact_retention_days }}
           if-no-files-found: error

--- a/.github/workflows/npm-pack.yml
+++ b/.github/workflows/npm-pack.yml
@@ -18,6 +18,11 @@ on:
 
     inputs:
 
+      artifact_retention_days:
+        required: false
+        type: number
+        default: 90
+
       npm_scope:
         description: The NPM 'scope' value to use.  Default is 'ritterim' as it needs to match the GitHub organization value.
         type: string
@@ -160,4 +165,5 @@ jobs:
         with:
           name: ${{ steps.set-outputs.outputs.artifact_name }}
           path: ${{ steps.set-outputs.outputs.artifact_file_path }}
+          retention-days: ${{ inputs.artifact_retention_days }}
           if-no-files-found: error


### PR DESCRIPTION
Allow the caller to specify how long artifacts should be stored in GitHub Actions.  Default of 90 days.

This applies to test / pack / publish workflows which call the 'actions/upload-artifact' action.