### PR TITLE
Add persisted_workspace_artifact_suffix input

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -20,6 +20,12 @@ on:
         type: string
         default: "6.0"
 
+      persisted_workspace_artifact_suffix:
+        description: By default, each persisted workspace artifact gets a random suffix appended to the base name.  This input can be used to provide a more meaningful name suffix.
+        default: 
+        type: string
+        required: false
+
       project_directory:
         description: Location of the solution file for the dotnet solution.  Defaults to the root directory.
         required: false
@@ -106,7 +112,9 @@ jobs:
 
       - name: Persist Workspace
         id: persist-workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.1
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.2
+        with:
+          artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}
 
       - run: ls -la ~/.nuget
 

--- a/.github/workflows/dotnet-npm-build.yml
+++ b/.github/workflows/dotnet-npm-build.yml
@@ -43,6 +43,12 @@ on:
         type: string
         default: ./
 
+      persisted_workspace_artifact_suffix:
+        description: By default, each persisted workspace artifact gets a random suffix appended to the base name.  This input can be used to provide a more meaningful name suffix.
+        default: 
+        type: string
+        required: false
+
       project_directory:
         description: Location of the solution file for the dotnet solution.  Defaults to the root directory.
         required: false
@@ -171,4 +177,6 @@ jobs:
 
       - name: Persist Workspace
         id: persist-workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.1
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.2
+        with:
+          artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}

--- a/.github/workflows/npm-build-test-public.yml
+++ b/.github/workflows/npm-build-test-public.yml
@@ -35,6 +35,12 @@ on:
         type: boolean
         default: false
 
+      persisted_workspace_artifact_suffix:
+        description: By default, each persisted workspace artifact gets a random suffix appended to the base name.  This input can be used to provide a more meaningful name suffix.
+        default: 
+        type: string
+        required: false
+
       project_directory:
         description: Location of the package.json file for the NPM package.
         required: false
@@ -122,4 +128,6 @@ jobs:
       - name: Persist Workspace
         id: persist-workspace
         if: inputs.persist_workspace == true
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.1
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.2
+        with:
+          artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -42,6 +42,12 @@ on:
         type: boolean
         default: false
 
+      persisted_workspace_artifact_suffix:
+        description: By default, each persisted workspace artifact gets a random suffix appended to the base name.  This input can be used to provide a more meaningful name suffix.
+        default: 
+        type: string
+        required: false
+
       project_directory:
         description: Location of the package.json file for the NPM package.
         required: false
@@ -135,4 +141,6 @@ jobs:
       - name: Persist Workspace
         id: persist-workspace
         if: inputs.persist_workspace == true
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.1
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.2
+        with:
+          artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}

--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -35,6 +35,12 @@ on:
         type: string
         default: package.json
 
+      persisted_workspace_artifact_suffix:
+        description: By default, each persisted workspace artifact gets a random suffix appended to the base name.  This input can be used to provide a more meaningful name suffix.
+        default: 
+        type: string
+        required: false
+
       project_directory:
         description: Location of the package.json file for the NPM package.
         required: false
@@ -113,4 +119,6 @@ jobs:
 
       - name: Persist Workspace
         id: persist-workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.1
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.2
+        with:
+          artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}

--- a/forks/persist-workspace/action.yml
+++ b/forks/persist-workspace/action.yml
@@ -20,6 +20,7 @@ inputs:
     required: false
 
   artifact_name_suffix:
+    description: By default, each persisted workspace artifact gets a random suffix appended to the base name.  This input can be used to provide a more meaningful name suffix.
     default: 
     required: false
 


### PR DESCRIPTION
Allow the caller, for reusable workflows which can persist the workspace, to specify the suffix for
the artifact.  Otherwise it will default to a random alphanumeric suffix to ensure uniqueness.