### PR TITLE
Fix bug in persist-workspace around custom suffixes

### DIFF
--- a/forks/persist-workspace/action.yml
+++ b/forks/persist-workspace/action.yml
@@ -70,7 +70,7 @@ runs:
       run: |
         GITHUBRUNID=${{ github.run_id }}
         RANDOMSUFFIX=$(dd if=/dev/urandom bs=12 count=1 status=none | base64 | tr -dc A-Za-z0-9)
-        ARTIFACTSUFFIX=${INPUTARTIFACTSUFFIX:$RANDOMSUFFIX}
+        ARTIFACTSUFFIX=${INPUTARTIFACTSUFFIX:-$RANDOMSUFFIX}
         ARTIFACTNAME=${INPUTARTIFACTNAME:-persisted-workspace-$ARTIFACTSUFFIX-$GITHUBRUNID}
         echo "ARTIFACTNAME=${ARTIFACTNAME}"
         echo "ARTIFACTNAME=${ARTIFACTNAME}" >> $GITHUB_ENV


### PR DESCRIPTION
When the inputs.artifact_name_suffix value is not provided, the code did not correctly fall back to the randomized suffix.

https://stackoverflow.com/a/2013589