### PR TITLE
Add our dotnet package build workflows

### DIFF
--- a/.github/workflows/dotnet-packages-pr-build.yml
+++ b/.github/workflows/dotnet-packages-pr-build.yml
@@ -1,0 +1,122 @@
+name: Package PR Build (.NET)
+
+# Designed for use with our projects which produce one more more NuGet packages
+# where the repo only produces NuGet packages (and not a website artifact).
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+
+on:
+
+  workflow_call:
+
+    inputs:
+
+      docker_mssql_image:
+        description: Supply an image/tag string if you need to startup the SQL for Docker service for tests.  Leave this input blank if you do not need the service.
+        type: string
+        required: false
+        default: ''
+
+      docker_mssql_port:
+        description: The port on which the SQL for Docker container will listen.
+        required: false
+        default: 11435
+        type: number
+
+      dotnet_version:
+        required: false
+        type: string
+        default: "6.0"
+
+      github_run_id_baseline:
+        description: The zero point for calculating the patch value from the 'github.run_id' value.
+        required: true
+        type: string # has to be string, because the caller is often passing in a GitHub Actions variable.
+
+      jfrog_api_url:
+        description: 'JFrog platform url (for example: https://rimdev.jfrog.io)'
+        required: false
+        default: 'https://rimdev.jfrog.io'
+        type: string
+
+      project_name:
+        required: true
+        type: string
+
+      project_directory:
+        required: false
+        type: string
+        default: "./"
+
+    secrets:
+
+      jfrog_api_key:
+        description: The secret API key needed in order to access the JFrog XRay API.
+        required: true
+
+jobs:
+
+  version:
+    uses: ritterim/public-github-actions/.github/workflows/calculate-version-from-txt-using-github-run-id.yml@v1.9.2
+    #uses: ./.github/workflows/calculate-version-from-txt-using-github-run-id.yml
+    with:
+      github_run_id_baseline: ${{ inputs.github_run_id_baseline }}
+      version_suffix: "-pr${{ github.event.number }}"
+
+  build:
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-build.yml@v1.9.2
+    #uses: ./.github/workflows/dotnet-build.yml
+    with:
+      dotnet_version: ${{ inputs.dotnet_version }}
+      project_directory: ${{ inputs.project_directory }}
+
+  dotnet-test:
+    needs: [ build, version ]
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-test.yml@v1.9.2
+    #uses: ./.github/workflows/dotnet-test.yml
+    with:
+      artifact_name: ${{ github.event.repository.name }}-testResults-${{ needs.version.outputs.informational_version }}
+      configuration: ${{ needs.build.outputs.configuration }}
+      dotnet_version: ${{ needs.build.outputs.dotnet_version }}
+      persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
+      project_directory: ${{ needs.build.outputs.project_directory }}
+      docker_mssql_image: ${{ inputs.docker_mssql_image }}
+      docker_mssql_port: ${{ inputs.docker_mssql_port }}
+
+  dotnet-pack:
+    needs: [ build, dotnet-test, version ]
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-pack.yml@v1.9.2
+    #uses: ./.github/workflows/dotnet-pack.yml
+    with:
+      artifact_name: ${{ github.event.repository.name }}-packages-${{ needs.version.outputs.informational_version }}
+      configuration: ${{ needs.build.outputs.configuration }}
+      dotnet_version: ${{ needs.build.outputs.dotnet_version }}
+      persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
+      project_directory: ${{ needs.build.outputs.project_directory }}
+      informational_version: ${{ needs.version.outputs.informational_version }}
+      version: ${{ needs.version.outputs.version }}
+
+  jfrog-xray-audit:
+    needs: [ build, version ]
+    uses: ritterim/public-github-actions/.github/workflows/jfrog-xray-audit.yml@v1.10.0
+    #uses: ./.github/workflows/jfrog-xray-audit.yml
+    secrets:
+      jfrog_api_key: ${{ secrets.jfrog_api_key }}
+    with:
+      persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
+      jfrog_api_url: ${{ inputs.jfrog_api_url }}
+      report_artifact_name: ${{ github.event.repository.name }}-xray-audit-${{ needs.version.outputs.informational_version }}
+
+  jfrog-xray-scan:
+    needs: [ dotnet-pack, version ]
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-jfrog-xray-scan.yml@v1.10.0
+    #uses: ./.github/workflows/dotnet-jfrog-xray-scan.yml
+    secrets:
+      jfrog_api_key: ${{ secrets.jfrog_api_key }}
+    with:
+      artifact_name: ${{ needs.dotnet-pack.outputs.artifact_name }}
+      jfrog_api_url: ${{ inputs.jfrog_api_url }}
+      report_artifact_name: ${{ github.event.repository.name }}-xray-scan-${{ needs.version.outputs.informational_version }}

--- a/.github/workflows/dotnet-private-packages-release-build.yml
+++ b/.github/workflows/dotnet-private-packages-release-build.yml
@@ -1,0 +1,128 @@
+name: Private Package Release Build (.NET)
+
+# This is only designed for use with private packages that get pushed
+# to our private feeds.
+
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
+on:
+
+  workflow_call:
+
+    inputs:
+
+      docker_mssql_image:
+        description: Supply an image/tag string if you need to startup the SQL for Docker service for tests.  Leave this input blank if you do not need the service.
+        type: string
+        required: false
+        default: ''
+
+      docker_mssql_port:
+        description: The port on which the SQL for Docker container will listen.
+        required: false
+        default: 11435
+        type: number
+
+      dotnet_version:
+        required: false
+        type: string
+        default: "6.0"
+
+      github_run_id_baseline:
+        description: The zero point for calculating the patch value from the 'github.run_id' value.
+        required: true
+        type: string # has to be string, because the caller is often passing in a GitHub Actions variable.
+
+      jfrog_api_url:
+        description: 'JFrog platform url (for example: https://rimdev.jfrog.io)'
+        required: false
+        default: 'https://rimdev.jfrog.io'
+        type: string
+
+      project_name:
+        required: true
+        type: string
+
+      project_directory:
+        required: false
+        type: string
+        default: "./"
+
+    secrets:
+
+      jfrog_api_key:
+        description: The secret API key needed in order to access the JFrog API.  Assumes that it is a JWT style token.  This API key will also need the ability to push artifacts to Artifactory.
+        required: true
+
+jobs:
+
+  version:
+    uses: ritterim/public-github-actions/.github/workflows/calculate-version-from-txt-using-github-run-id.yml@v1.9.2
+    #uses: ./.github/workflows/calculate-version-from-txt-using-github-run-id.yml
+    with:
+      github_run_id_baseline: ${{ inputs.github_run_id_baseline }}
+
+  build:
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-build.yml@v1.9.2
+    #uses: ./.github/workflows/dotnet-build.yml
+    with:
+      dotnet_version: ${{ inputs.dotnet_version }}
+      project_directory: ${{ inputs.project_directory }}
+
+  dotnet-test:
+    needs: [ build, version ]
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-test.yml@v1.9.2
+    #uses: ./.github/workflows/dotnet-test.yml
+    with:
+      artifact_name: ${{ github.event.repository.name }}-testResults-${{ needs.version.outputs.informational_version }}
+      configuration: ${{ needs.build.outputs.configuration }}
+      dotnet_version: ${{ needs.build.outputs.dotnet_version }}
+      persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
+      project_directory: ${{ needs.build.outputs.project_directory }}
+      docker_mssql_image: ${{ inputs.docker_mssql_image }}
+      docker_mssql_port: ${{ inputs.docker_mssql_port }}
+
+  dotnet-pack:
+    needs: [ build, dotnet-test, version ]
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-pack.yml@v1.9.2
+    #uses: ./.github/workflows/dotnet-pack.yml
+    with:
+      artifact_name: ${{ github.event.repository.name }}-packages-${{ needs.version.outputs.informational_version }}
+      configuration: ${{ needs.build.outputs.configuration }}
+      dotnet_version: ${{ needs.build.outputs.dotnet_version }}
+      persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
+      project_directory: ${{ needs.build.outputs.project_directory }}
+      informational_version: ${{ needs.version.outputs.informational_version }}
+      version: ${{ needs.version.outputs.version }}
+
+  dotnet-push-github:
+    needs: [ dotnet-pack ]
+    uses: ritterim/github-actions/.github/workflows/dotnet-push-github.yml@v1.2023.1016
+    with:
+      artifact_name: ${{ needs.dotnet-pack.outputs.artifact_name }}
+
+
+  jfrog-xray-audit:
+    needs: [ build, version ]
+    uses: ritterim/public-github-actions/.github/workflows/jfrog-xray-audit.yml@v1.10.0
+    #uses: ./.github/workflows/jfrog-xray-audit.yml
+    secrets:
+      jfrog_api_key: ${{ secrets.jfrog_api_key }}
+    with:
+      persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
+      jfrog_api_url: ${{ inputs.jfrog_api_url }}
+      report_artifact_name: ${{ github.event.repository.name }}-xray-audit-${{ needs.version.outputs.informational_version }}
+
+  jfrog-xray-scan:
+    needs: [ dotnet-pack, version ]
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-jfrog-xray-scan.yml@v1.10.0
+    #uses: ./.github/workflows/dotnet-jfrog-xray-scan.yml
+    secrets:
+      jfrog_api_key: ${{ secrets.jfrog_api_key }}
+    with:
+      artifact_name: ${{ needs.dotnet-pack.outputs.artifact_name }}
+      jfrog_api_url: ${{ inputs.jfrog_api_url }}
+      report_artifact_name: ${{ github.event.repository.name }}-xray-scan-${{ needs.version.outputs.informational_version }}


### PR DESCRIPTION
These are used for our repos that produce only NuGet packages (no website artifacts).

- Includes JFrog XRay audit/scan jobs.
- Pushes to GitHub Packages.
- Does *not* yet push to JFrog Artifactory.

In most cases, you would heavily customize these for your usage and not consume it directly.