### PR TITLE
Add jfrog-artifactory-repository-name-validator

### DIFF
--- a/actions/jfrog-artifactory-repository-name-validator/LICENSE
+++ b/actions/jfrog-artifactory-repository-name-validator/LICENSE
@@ -1,0 +1,22 @@
+
+The MIT License (MIT)
+
+Copyright (c) 2023 Ritter Insurance Marketing and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/actions/jfrog-artifactory-repository-name-validator/action.yml
+++ b/actions/jfrog-artifactory-repository-name-validator/action.yml
@@ -1,0 +1,32 @@
+name: jfrog-artifactory-repository-name-validator
+description: Validate that the name value matches a regex pattern for JFrog Artifactory Repository names.
+author: RIMdev <RIMdev@RitterIM.com>
+branding:
+  icon: 'check-square'  
+  color: 'blue'
+
+inputs:
+
+  name:
+    required: true
+
+  required:
+    required: false
+    default: true
+
+  error_if_not_valid:
+    required: false
+    default: true
+
+runs:
+  using: "composite"
+
+  steps:
+
+    - name: Validate
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      with:
+        value: ${{ inputs.name }}
+        regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
+        required: ${{ inputs.required }}
+        error_if_not_valid: ${{ inputs.error_if_not_valid }}


### PR DESCRIPTION
A validator for JFrog Artifactory repository names which only allows alphanumeric (mixed case) and hyphens.

https://jfrog.com/whitepaper/best-practices-structuring-naming-artifactory-repositories/