### PR TITLE
Only push "*.nupkg" with dotnet nuget push

### DIFF
--- a/.github/workflows/dotnet-push-github.yml
+++ b/.github/workflows/dotnet-push-github.yml
@@ -35,12 +35,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.10.0
         with:
           file_name: ${{ inputs.artifact_name }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.10.0
         with:
           path_name: ${{ inputs.project_directory }}
 
@@ -57,4 +57,4 @@ jobs:
       - name: dotnet push (GitHub)
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: dotnet nuget push '*.*nupkg' --api-key "$NUGET_AUTH_TOKEN" --source "https://nuget.pkg.github.com/ritterim/index.json"
+        run: dotnet nuget push '*.nupkg' --api-key "$NUGET_AUTH_TOKEN" --source "https://nuget.pkg.github.com/ritterim/index.json"


### PR DESCRIPTION
Doing the wildcard resulted in *.snupkg files erroring out because 'dotnet nuget push' is already going to send them along with the '.nupkg' file.