### PR TITLE
Spit out the report file in the last step

### DIFF
--- a/.github/workflows/jfrog-xray-audit.yml
+++ b/.github/workflows/jfrog-xray-audit.yml
@@ -136,6 +136,13 @@ jobs:
           retention-days: ${{ inputs.report_artifact_retention_days }}
           if-no-files-found: error
 
+      # TODO: Post the report text back to the pull request?
+
+      # Spit out the report file again, because this is the step that will go angry-red
+      # when the audit is not successful.  By repeating it here, the dev doesn't have
+      # to scroll up to a prior step when there is an issue.
       - name: Fail build on audit error
         if: steps.audit.outcome == 'failure'
-        run: exit 1
+        run: |
+          cat "${REPORTARTIFACTNAME}.txt"
+          exit 1


### PR DESCRIPTION
This tripped me up.  When the build failed, I went and looked for the failed step and ended up here.  But it confused me because there were no messages to indicate why the build failed.  The actual failure message was back up in the 'audit' step.

So to make things simple for those of us who haven't had enough coffee in the morning, we'll spit out the report text in this step for ease of use.
