### PR TITLE
Remove excess GH token permissions from 'jf audit'

### DIFF
--- a/.github/workflows/jfrog-xray-audit.yml
+++ b/.github/workflows/jfrog-xray-audit.yml
@@ -5,8 +5,6 @@ name: JFrog XRay Audit
 
 permissions:
   contents: read
-  id-token: write
-  packages: read
 
 on:
 


### PR DESCRIPTION
The jfrog-xray-audit.yml reusable workflow has no need for the 'id-token: write' or 'packages: read' permissions. If we're using JFrog, then we'll be pulling everything out of Artifactory instead of GitHub Packages.