### PR TITLE
Create dotnet-test-jfrog.yml reusable workflow

### DIFF
--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -1,0 +1,268 @@
+name: Test (.NET)
+
+# Uses JFrog Artifactory as the sole upstream repository for resolving the NuGet packages.
+# It's expected that you point at a 'virtual' Artifactory repository which can also
+# resolve any public NuGet packages which you consume.
+
+# At the moment, this requires a user-generated JWT for the authentication.
+
+permissions:
+  contents: read
+
+on:
+
+  workflow_call:
+
+    inputs:
+
+      artifact_name:
+        required: true
+        type: string
+
+      artifact_retention_days:
+        required: false
+        type: number
+        default: 90
+
+      configuration:
+        required: true
+        type: string
+
+      docker_azurite_image:
+        description: Supply an image/tag string if you need to startup the Azurite service for tests.  Leave this input blank if you do not need the service.  The service will be started on the standard 10000-10002 ports.
+        type: string
+        required: false
+        default: ''
+
+      docker_elasticsearch_image:
+        description: Supply an image/tag string if you need to startup the Elasticsearch service for tests.  Leave this input blank if you do not need the service.
+        type: string
+        required: false
+        default: ''
+
+      docker_elasticsearch_http_port:
+        description: The port on which the Elasticsearch service will listen for http.
+        required: false
+        default: 9206
+        type: number
+
+      docker_elasticsearch_transport_port:
+        description: The port on which the Elasticsearch service will listen for transport.
+        required: false
+        default: 9306
+        type: number
+
+      docker_mssql_image:
+        description: Supply an image/tag string if you need to startup the SQL for Docker service for tests.  Leave this input blank if you do not need the service.
+        type: string
+        required: false
+        default: ''
+
+      docker_mssql_port:
+        description: The port on which the SQL for Docker container will listen.
+        required: false
+        default: 11435
+        type: number
+
+      docker_redis_image:
+        description: Supply an image/tag string if you need to startup the Redis Docker service for tests.  Leave this input blank if you do not need the service.
+        type: string
+        required: false
+        default: ''
+
+      docker_redis_port:
+        description: The port on which the Redis Docker container will listen.
+        required: false
+        default: 6379
+        type: number
+
+      dotnet_version:
+        required: false
+        type: string
+        default: "6.0"
+
+      jfrog_api_base_url:
+        description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
+        required: true
+        type: string
+
+      jfrog_api_username:
+        description: The JFrog username associated with the jfrog_api_key.
+        required: true
+        type: string
+
+      jfrog_nuget_feed_repo:
+        description: The 'virtual' JFrog Artifactory repository identifier for NuGet package retrieval.
+        required: true
+        type: string
+
+      persisted_workspace_artifact_name:
+        description: Name of the artifact which contains the persisted workspace directory.
+        required: true
+        type: string
+
+      project_directory:
+        description: Location of the solution file for the dotnet solution.  Defaults to the root directory.
+        required: false
+        type: string
+        default: ./
+
+      run_tests:
+        required: false
+        type: boolean
+        default: true
+
+    secrets:
+
+      jfrog_api_key:
+        description: The secret API key needed in order to access the JFrog XRay API and pull packages.
+        required: true
+
+jobs:
+
+  tests:
+    name: Test (.NET)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+          working-directory: ${{ inputs.project_directory }}
+
+    env:
+      ARTIFACTNAME: ${{ inputs.artifact_name }}
+      CONFIGURATION: ${{ inputs.configuration }}
+      NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
+      PROJECTDIRECTORY: ${{ inputs.project_directory }}
+      RIMDEVTESTS__ELASTICSEARCH__PORT: ${{ inputs.docker_elasticsearch_http_port }}
+      RIMDEVTESTS__ELASTICSEARCH__TRANSPORTPORT: ${{ inputs.docker_elasticsearch_transport_port }}
+      RIMDEVTESTS__SQL__PORT: ${{ inputs.docker_mssql_port }}
+      # The SQL password just needs to be not-empty, it's a temporary database
+      RIMDEVTESTS__SQL__PASSWORD: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+      # Elasticsearch
+      discovery.type: single-node
+      ES_JAVA_OPTS: -Xms256m -Xmx256m
+      JFROG_API_KEY: ${{ secrets.jfrog_api_key }}
+      JFROG_API_BASE_URL: ${{ inputs.jfrog_api_base_url }}
+      JFROG_API_USERNAME: ${{ inputs.jfrog_api_username }}
+      JFROG_NUGET_FEED_NAME: jfrog-${{ inputs.jfrog_nuget_feed_repo }}
+      JFROG_NUGET_FEED_REPO: ${{ inputs.jfrog_nuget_feed_repo }}
+      JFROG_NUGET_FEED_REPO_URL: "${{ inputs.jfrog_api_base_url }}artifactory/api/nuget/v3/${{ inputs.jfrog_nuget_feed_repo }}/index.json"
+
+    services:
+
+      azurite:
+        image: ${{ inputs.docker_azurite_image }}
+        ports:
+          - 10000:10000
+          - 10001:10001
+          - 10002:10002
+
+      elasticsearch:
+        image: ${{ inputs.docker_elasticsearch_image }}
+        ports:
+          - ${{ inputs.docker_elasticsearch_http_port }}:9200
+          - ${{ inputs.docker_elasticsearch_transport_port }}:9300
+
+      mssql:
+        image: ${{ inputs.docker_mssql_image }}
+        env:
+          SA_PASSWORD: ${{ env.RIMDEVTESTS__SQL__PASSWORD }}
+          ACCEPT_EULA: 'Y'
+        ports:
+          - ${{ inputs.docker_mssql_port }}:1433
+
+      redis:
+        image: ${{ inputs.docker_redis_image }}
+        ports:
+          - ${{ inputs.docker_redis_port }}:6379
+
+    steps:
+
+      - name: Validate inputs.artifact_name
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        with:
+          file_name: ${{ env.ARTIFACTNAME }}
+
+      - name: Validate inputs.configuration
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        with:
+          case_sensitive: false
+          regex_pattern: "^debug|release$"
+          value: ${{ env.CONFIGURATION }}
+
+      - name: Validate inputs.jfrog_nuget_feed_repo
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.10.0
+        with:
+          name: ${{ env.JFROG_NUGET_FEED_REPO }}
+
+      - name: Validate inputs.project_directory
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        with:
+          path_name: ${{ env.PROJECTDIRECTORY }}
+
+      - name: Validate RIMDEVTESTS__SQL__PASSWORD (must be 8-250 chars)
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        if: inputs.docker_mssql_image != ''
+        with:
+          value: ${{ env.RIMDEVTESTS__SQL__PASSWORD }}
+          regex_pattern: "^.{8,250}$"
+
+      - name: Bypass Tests
+        if: inputs.run_tests != true
+        working-directory: ./
+        run: echo "The 'inputs.run_tests' value is FALSE, skipping tests!"
+
+      - name: Restore Workspace
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.2
+        if: inputs.run_tests == true
+        with:
+          action: retrieve
+          artifact_name: ${{ inputs.persisted_workspace_artifact_name }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      # Remove predefined NuGet sources
+      - run: dotnet nuget list source
+      - run: dotnet nuget remove source NuGet
+        continue-on-error: true
+      - run: dotnet nuget remove source nuget.org
+        continue-on-error: true
+      - run: dotnet nuget list source
+
+      - run: dotnet nuget add source "${JFROG_NUGET_FEED_REPO_URL}" --name "${JFROG_NUGET_FEED_NAME}" --username "${JFROG_API_USERNAME}" --password "${JFROG_API_KEY}" --store-password-in-clear-text
+      - run: dotnet nuget list source
+
+      - name: Setup ~/.nuget/packages cache
+        uses: actions/cache@v3
+        if: inputs.run_tests == true
+        with:
+          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
+          path: |
+            ~/.nuget/packages
+
+      # https://github.com/dotnet/core/issues/7412
+      # We can't feed in --no-build or --no-restore or else the test command will just fail silently
+      # instead of throwing an error when it fails to restore the dependencies.
+      - name: dotnet test
+        if: inputs.run_tests == true
+        run: |
+          dotnet test \
+            --logger "console;verbosity=normal" \
+            --logger "trx;logfilename=testResults.trx" \
+            --configuration "${CONFIGURATION}"
+
+      - name: Find .trx files
+        if: inputs.run_tests == true
+        run: find . -name '*.trx' -type f
+
+      - name: Upload Artifacts
+        id: upload-artifact
+        uses: actions/upload-artifact@v3
+        if: inputs.run_tests == true
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: "${{ inputs.project_directory }}**/*.trx"
+          retention-days: ${{ inputs.artifact_retention_days }}
+          if-no-files-found: error


### PR DESCRIPTION
Using JFrog Artifactory as the sole package provider for NuGet files makes things different enough from the base 'dotnet-test.yml' file to be worth a separate workflow.