### PR TITLE
Remove 'packages: read' perm from dotnet-pack.yml

### DIFF
--- a/.github/workflows/dotnet-pack.yml
+++ b/.github/workflows/dotnet-pack.yml
@@ -4,7 +4,6 @@ name: Pack (.NET)
 
 permissions:
   contents: read
-  packages: read
 
 on:
 
@@ -110,9 +109,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
-          source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup ~/.nuget/packages cache
         uses: actions/cache@v3


### PR DESCRIPTION
We should be able to get away with not needing to access any NuGet package feeds (such as GH Pkgs) when doing the 'dotnet pack' step.