### PR TITLE
Switch NuGet package workflows to use JF builds [BREAKING]

### DIFF
--- a/.github/workflows/dotnet-packages-pr-build.yml
+++ b/.github/workflows/dotnet-packages-pr-build.yml
@@ -3,7 +3,6 @@ name: Package PR Build (.NET)
 permissions:
   contents: read
   id-token: write
-  packages: read
 
 on:
 
@@ -35,8 +34,17 @@ on:
 
       jfrog_api_base_url:
         description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
-        required: false
-        default: 'https://rimdev.jfrog.io/'
+        required: true
+        type: string
+
+      jfrog_api_username:
+        description: The JFrog username associated with the jfrog_api_key.
+        required: true
+        type: string
+
+      jfrog_nuget_feed_repo:
+        description: The 'virtual' JFrog Artifactory repository identifier for NuGet package retrieval.
+        required: true
         type: string
 
       jfrog_xray_watch_list:
@@ -56,7 +64,7 @@ on:
     secrets:
 
       jfrog_api_key:
-        description: The secret API key needed in order to access the JFrog XRay API.
+        description: The secret API key needed in order to access the JFrog XRay API and pull packages.
         required: true
 
 jobs:
@@ -69,20 +77,30 @@ jobs:
       version_suffix: "-pr${{ github.event.number }}"
 
   build:
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-build.yml@v1.11.0
-    #uses: ./.github/workflows/dotnet-build.yml
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.11.0
+    #uses: ./.github/workflows/dotnet-build-jfrog.yml
+    secrets:
+      jfrog_api_key: ${{ secrets.jfrog_api_key }}
     with:
       dotnet_version: ${{ inputs.dotnet_version }}
+      jfrog_api_base_url: ${{ inputs.jfrog_api_base_url }}
+      jfrog_api_username: ${{ inputs.jfrog_api_username }}
+      jfrog_nuget_feed_repo: ${{ inputs.jfrog_nuget_feed_repo }}
       project_directory: ${{ inputs.project_directory }}
 
   dotnet-test:
     needs: [ build, version ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-test.yml@v1.11.0
-    #uses: ./.github/workflows/dotnet-test.yml
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-test-jfrog.yml@v1.11.0
+    #uses: ./.github/workflows/dotnet-test-jfrog.yml
+    secrets:
+      jfrog_api_key: ${{ secrets.jfrog_api_key }}
     with:
       artifact_name: ${{ github.event.repository.name }}-testResults-${{ needs.version.outputs.informational_version }}
       configuration: ${{ needs.build.outputs.configuration }}
       dotnet_version: ${{ needs.build.outputs.dotnet_version }}
+      jfrog_api_base_url: ${{ inputs.jfrog_api_base_url }}
+      jfrog_api_username: ${{ inputs.jfrog_api_username }}
+      jfrog_nuget_feed_repo: ${{ inputs.jfrog_nuget_feed_repo }}
       persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
       project_directory: ${{ needs.build.outputs.project_directory }}
       docker_mssql_image: ${{ inputs.docker_mssql_image }}

--- a/.github/workflows/dotnet-private-packages-release-build.yml
+++ b/.github/workflows/dotnet-private-packages-release-build.yml
@@ -38,12 +38,21 @@ on:
 
       jfrog_api_base_url:
         description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
-        required: false
-        default: 'https://rimdev.jfrog.io/'
+        required: true
         type: string
 
-      jfrog_artifactory_repository:
-        description: 'JFrog Artifactory repository identifier.'
+      jfrog_api_username:
+        description: The JFrog username associated with the jfrog_api_key.
+        required: true
+        type: string
+
+      jfrog_nuget_feed_repo:
+        description: The 'virtual' JFrog Artifactory repository identifier for NuGet package retrieval.
+        required: true
+        type: string
+
+      jfrog_artifactory_package_push_repository:
+        description: 'JFrog Artifactory repository identifier where the package will be pushed to.'
         required: true
         type: string
 
@@ -64,7 +73,7 @@ on:
     secrets:
 
       jfrog_api_key:
-        description: The secret API key needed in order to access the JFrog XRay API.
+        description: The secret API key needed in order to access the JFrog XRay API and pull packages.
         required: true
 
       jfrog_publish_api_key:
@@ -80,20 +89,30 @@ jobs:
       github_run_id_baseline: ${{ inputs.github_run_id_baseline }}
 
   build:
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-build.yml@v1.11.0
-    #uses: ./.github/workflows/dotnet-build.yml
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.11.0
+    #uses: ./.github/workflows/dotnet-build-jfrog.yml
+    secrets:
+      jfrog_api_key: ${{ secrets.jfrog_api_key }}
     with:
       dotnet_version: ${{ inputs.dotnet_version }}
+      jfrog_api_base_url: ${{ inputs.jfrog_api_base_url }}
+      jfrog_api_username: ${{ inputs.jfrog_api_username }}
+      jfrog_nuget_feed_repo: ${{ inputs.jfrog_nuget_feed_repo }}
       project_directory: ${{ inputs.project_directory }}
 
   dotnet-test:
     needs: [ build, version ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-test.yml@v1.11.0
-    #uses: ./.github/workflows/dotnet-test.yml
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-test-jfrog.yml@v1.11.0
+    #uses: ./.github/workflows/dotnet-test-jfrog.yml
+    secrets:
+      jfrog_api_key: ${{ secrets.jfrog_api_key }}
     with:
       artifact_name: ${{ github.event.repository.name }}-testResults-${{ needs.version.outputs.informational_version }}
       configuration: ${{ needs.build.outputs.configuration }}
       dotnet_version: ${{ needs.build.outputs.dotnet_version }}
+      jfrog_api_base_url: ${{ inputs.jfrog_api_base_url }}
+      jfrog_api_username: ${{ inputs.jfrog_api_username }}
+      jfrog_nuget_feed_repo: ${{ inputs.jfrog_nuget_feed_repo }}
       persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
       project_directory: ${{ needs.build.outputs.project_directory }}
       docker_mssql_image: ${{ inputs.docker_mssql_image }}
@@ -140,5 +159,5 @@ jobs:
     with:
       artifact_name: ${{ needs.dotnet-pack.outputs.artifact_name }}
       jfrog_api_base_url: ${{ inputs.jfrog_api_base_url }}
-      jfrog_artifactory_repository: ${{ inputs.jfrog_artifactory_repository }}
+      jfrog_artifactory_repository: ${{ inputs.jfrog_artifactory_package_push_repository }}
       persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}


### PR DESCRIPTION
Switch to using 'dotnet-build-jfrog.yml' and the 'dotnet-test-jfrog.yml' variants for build/test. This requires additional inputs to these two workflows to handle passing the JFrog user name.

It also switches the build/test steps to only pull packages via the JFrog Artifactory virtual repo so that everything flows through JFrog security.