### PR TITLE
[BREAKING] Rename 'jfrog_xray_watch_list' input

### DIFF
--- a/.github/workflows/dotnet-packages-pr-build.yml
+++ b/.github/workflows/dotnet-packages-pr-build.yml
@@ -46,7 +46,7 @@ on:
         required: true
         type: string
 
-      jfrog_xray_watch_list:
+      jfrog_audit_xray_watch_list:
         description: Comma-delimited list (with no spaces) of XRay watches to enforce.  Passed to "jf audit" via the "--watches" argument.
         required: true
         type: string
@@ -113,7 +113,7 @@ jobs:
       jfrog_api_key: ${{ secrets.jfrog_api_key }}
     with:
       jfrog_api_base_url: ${{ inputs.jfrog_api_base_url }}
-      jfrog_xray_watch_list: ${{ inputs.jfrog_xray_watch_list }}
+      jfrog_xray_watch_list: ${{ inputs.jfrog_audit_xray_watch_list }}
       persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
       report_artifact_name: ${{ github.event.repository.name }}-xray-audit-${{ needs.version.outputs.informational_version }}
 

--- a/.github/workflows/dotnet-private-packages-release-build.yml
+++ b/.github/workflows/dotnet-private-packages-release-build.yml
@@ -56,7 +56,7 @@ on:
         required: true
         type: string
 
-      jfrog_xray_watch_list:
+      jfrog_audit_xray_watch_list:
         description: Comma-delimited list (with no spaces) of XRay watches to enforce.  Passed to "jf audit" via the "--watches" argument.
         required: true
         type: string
@@ -126,7 +126,7 @@ jobs:
       jfrog_api_key: ${{ secrets.jfrog_api_key }}
     with:
       jfrog_api_base_url: ${{ inputs.jfrog_api_base_url }}
-      jfrog_xray_watch_list: ${{ inputs.jfrog_xray_watch_list }}
+      jfrog_xray_watch_list: ${{ inputs.jfrog_audit_xray_watch_list }}
       persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
       report_artifact_name: ${{ github.event.repository.name }}-xray-audit-${{ needs.version.outputs.informational_version }}
 


### PR DESCRIPTION
This input is used for the 'jf audit' step, so we should add the word "audit" to the parameter name.

This only affects the C#/NuGet package build workflows.