### PR TITLE
Revert "Temporary fix for JFrog Artifactory proxy issues"

### DIFF
--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -153,9 +153,6 @@ jobs:
       - name: dotnet nuget add source JFROG_NUGET_FEED_NAME
         run: dotnet nuget add source "${JFROG_NUGET_FEED_REPO_URL}" --name "${JFROG_NUGET_FEED_NAME}" --username "${JFROG_API_USERNAME}" --password "${JFROG_API_KEY}" --store-password-in-clear-text
 
-      # Temporary fix for the proxy issue in JFrog Artifactory
-      - run: dotnet nuget add source https://api.nuget.org/v3/index.json --name nuget.org
-
       - run: dotnet nuget list source
 
       - name: Setup ~/.nuget/packages cache

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -234,9 +234,6 @@ jobs:
       - name: dotnet nuget add source JFROG_NUGET_FEED_NAME
         run: dotnet nuget add source "${JFROG_NUGET_FEED_REPO_URL}" --name "${JFROG_NUGET_FEED_NAME}" --username "${JFROG_API_USERNAME}" --password "${JFROG_API_KEY}" --store-password-in-clear-text
 
-      # Temporary fix for the proxy issue in JFrog Artifactory
-      - run: dotnet nuget add source https://api.nuget.org/v3/index.json --name nuget.org
-
       - run: dotnet nuget list source
 
       - name: Setup ~/.nuget/packages cache


### PR DESCRIPTION
This reverts commit b2104f22948a284c2d747f94b05d49ea8d59469c.

We found a setting in the JFrog Artifactory remote repo advanced settings named "Synchronize properties".
If this setting is not turned on, Artifactory will only fetch metadata from the upstream feed and will *not* fetch the package binary artifact associated with the metadata.