### PR TITLE
Create frogbot repo scan workflow for private repos

### DIFF
--- a/.github/workflows/dotnet-frogbot-private-repo-scan.yml
+++ b/.github/workflows/dotnet-frogbot-private-repo-scan.yml
@@ -1,0 +1,228 @@
+name: "Frogbot Scan Repository"
+
+# This reusable workflow is designed for private GitHub repositories based on .NET.
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+on:
+
+  workflow_call:
+
+    inputs:
+
+      configuration:
+        required: false
+        type: string
+        default: "Release"
+
+      dotnet_version:
+        required: false
+        type: string
+        default: "6.0"
+
+      jfrog_api_base_url:
+        description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
+        required: true
+        type: string
+
+      jfrog_api_username:
+        description: The JFrog username associated with the jfrog_api_key.
+        required: true
+        type: string
+
+      jfrog_nuget_feed_repo:
+        description: The 'virtual' JFrog Artifactory repository identifier for NuGet package retrieval.
+        required: true
+        type: string
+
+      jfrog_xray_watch_list:
+        description: Comma-delimited list (with no spaces) of XRay watches to enforce.  Passed to "jf audit" via the "--watches" argument.
+        required: true
+        type: string
+
+      project_directory:
+        description: Location of the solution file for the dotnet solution.  Defaults to the root directory.
+        required: false
+        type: string
+        default: ./
+
+    secrets:
+
+      jfrog_api_key:
+        description: The secret API key (JWT) needed in order to access the JFrog XRay API and pull packages.
+        required: true
+
+jobs:
+
+  frogbot:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.project_directory }}
+
+    env:
+      CONFIGURATION: ${{ inputs.configuration }}
+      NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
+      PROJECTDIRECTORY: ${{ inputs.project_directory }}
+      JFROG_API_KEY: ${{ secrets.jfrog_api_key }}
+      JFROG_API_BASE_URL: ${{ inputs.jfrog_api_base_url }}
+      JFROG_API_USERNAME: ${{ inputs.jfrog_api_username }}
+      JFROG_NUGET_FEED_REPO: ${{ inputs.jfrog_nuget_feed_repo }}
+      JFROG_XRAY_WATCHES: ${{ inputs.jfrog_xray_watch_list }}
+
+    steps:
+
+      - name: Validate inputs.configuration
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        with:
+          case_sensitive: false
+          regex_pattern: "^debug|release$"
+          value: ${{ env.CONFIGURATION }}
+
+      - name: Validate inputs.jfrog_nuget_feed_repo
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.10.0
+        with:
+          name: ${{ env.JFROG_NUGET_FEED_REPO }}
+
+      - name: Validate inputs.project_directory
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        with:
+          path_name: ${{ env.PROJECTDIRECTORY }}
+
+      - name: Validate secrets.jfrog_api_key JWT
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        with:
+          regex_pattern: '^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$'
+          value: ${{ env.JFROG_API_KEY }}
+
+      - name: github context debug information
+        working-directory: ./
+        run: |
+          echo "github.base_ref=${{ github.base_ref }}"
+          echo "github.head_ref=${{ github.head_ref }}"
+          echo "github.ref=${{ github.ref }}"
+          echo "github.ref_name=${{ github.ref_name }}"
+          echo "github.repository=${{ github.repository }}"
+          echo "github.repository_owner=${{ github.repository_owner }}"
+          echo "github.sha=${{ github.sha }}"
+
+      - name: Checkout Project
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Setup ~/.nuget/packages cache
+        uses: actions/cache@v3
+        with:
+          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
+          path: |
+            ~/.nuget/packages
+
+      - uses: jfrog/frogbot@v2
+        env:
+          JFROG_CLI_LOG_LEVEL: "DEBUG"
+
+          # [Mandatory]
+          # JFrog platform URL (This functionality requires version 3.29.0 or above of Xray)
+          JF_URL: ${{ env.JFROG_API_BASE_URL }}
+
+          # [Mandatory if JF_USER and JF_PASSWORD are not provided]
+          # JFrog access token with 'read' permissions on Xray service
+          JF_ACCESS_TOKEN: ${{ env.JFROG_API_KEY }}
+
+          # [Mandatory]
+          # The GitHub token is automatically generated for the job
+          JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # [Mandatory]
+          # The name of the branch on which Frogbot will perform the scan
+          JF_GIT_BASE_BRANCH: ${{ github.ref }}
+
+          # [Optional, default: https://api.github.com]
+          # API endpoint to GitHub
+          # JF_GIT_API_ENDPOINT: https://github.example.com
+
+          # [Optional]
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user who has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
+          # JF_RELEASES_REPO: ""
+
+          ##########################################################################
+          ##   If your project uses a 'frogbot-config.yml' file, you can define   ##
+          ##   the following variables inside the file, instead of here.          ##
+          ##########################################################################
+
+          # [Optional, default: "."]
+          # Relative path to the root of the project in the Git repository
+          JF_WORKING_DIR: ${{ env.PROJECTDIRECTORY }}
+
+          # [Optional]
+          # Xray Watches. Learn more about them here: https://www.jfrog.com/confluence/display/JFROG/Configuring+Xray+Watches
+          JF_WATCHES: ${{ env.JFROG_XRAY_WATCHES }}
+
+          # [Optional]
+          # JFrog project. Learn more about it here: https://www.jfrog.com/confluence/display/JFROG/Projects
+          # JF_PROJECT: <project-key>
+
+          # [Optional, default: "TRUE"]
+          # Fails the Frogbot task if any security issue is found.
+          # JF_FAIL: "FALSE"
+
+          # [Optional]
+          # Frogbot will download the project dependencies, if they're not cached locally. To download the
+          # dependencies from a virtual repository in Artifactory, set the name of the repository. There's no
+          # need to set this value, if it is set in the frogbot-config.yml file.
+          JF_DEPS_REPO: ${{ env.JFROG_NUGET_FEED_REPO }}
+
+          # [Optional]
+          # Template for the branch name generated by Frogbot when creating pull requests with fixes.
+          # The template must include {BRANCH_NAME_HASH}, to ensure that the generated branch name is unique.
+          # The template can optionally include the {IMPACTED_PACKAGE} and {FIX_VERSION} variables.
+          # JF_BRANCH_NAME_TEMPLATE: "frogbot-{IMPACTED_PACKAGE}-{BRANCH_NAME_HASH}"
+
+          # [Optional]
+          # Template for the commit message generated by Frogbot when creating pull requests with fixes
+          # The template can optionally include the {IMPACTED_PACKAGE} and {FIX_VERSION} variables.
+          # JF_COMMIT_MESSAGE_TEMPLATE: "Upgrade {IMPACTED_PACKAGE} to {FIX_VERSION}"
+
+          # [Optional]
+          # Template for the pull request title generated by Frogbot when creating pull requests with fixes.
+          # The template can optionally include the {IMPACTED_PACKAGE} and {FIX_VERSION} variables.
+          # JF_PULL_REQUEST_TITLE_TEMPLATE: "[🐸 Frogbot] Upgrade {IMPACTED_PACKAGE} to {FIX_VERSION}"
+
+          # [Optional, Default: "FALSE"]
+          # If TRUE, Frogbot creates a single pull request with all the fixes.
+          # If FALSE, Frogbot creates a separate pull request for each fix.
+          # JF_GIT_AGGREGATE_FIXES: "FALSE"
+
+          # [Optional, Default: "FALSE"]
+          # Handle vulnerabilities with fix versions only
+          # JF_FIXABLE_ONLY: "TRUE"
+
+          # [Optional]
+          # Set the minimum severity for vulnerabilities that should be fixed and commented on in pull requests
+          # The following values are accepted: Low, Medium, High or Critical
+          JF_MIN_SEVERITY: "High"
+
+          # [Optional, Default: eco-system+frogbot@jfrog.com]
+          # Set the email of the commit author
+          # JF_GIT_EMAIL_AUTHOR: ""


### PR DESCRIPTION
Private GitHub repositories require a few extra hoops in order to get frogbot working.