### PR TITLE
BREAKING: New versions of JFrog .NET build/pack steps

### DIFF
--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -4,10 +4,14 @@ name: Build (.NET)
 # It's expected that you point at a 'virtual' Artifactory repository which can also
 # resolve any public NuGet packages which you consume.
 
-# At the moment, this requires a user-generated JWT for the authentication.
+# The "jfrog/setup-jfrog-cli" action requires "id-token: write" or else you will get
+# an error about: "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable".
+
+# https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli/cli-for-jfrog-artifactory/build-integration#aggregating-published-builds
 
 permissions:
   contents: read
+  id-token: write
 
 on:
 
@@ -30,13 +34,23 @@ on:
         required: true
         type: string
 
-      jfrog_api_username:
-        description: The JFrog username associated with the jfrog_api_key.
+      jfrog_build_name:
+        description: 'JFrog build name.'
+        required: true
+        type: string
+
+      jfrog_build_number:
+        description: 'JFrog build number. Can be an integer, a semantic version, or a string.'
         required: true
         type: string
 
       jfrog_nuget_feed_repo:
         description: The 'virtual' JFrog Artifactory repository identifier for NuGet package retrieval.
+        required: true
+        type: string
+
+      jfrog_oidc_provider_name:
+        description: The OIDC Integration Provider Name to use for authentication from the GitHub Action to the JFrog instance.
         required: true
         type: string
 
@@ -52,12 +66,6 @@ on:
         type: string
         default: ./
 
-    secrets:
-
-      jfrog_api_key:
-        description: The secret API key (JWT) needed in order to access the JFrog XRay API and pull packages.
-        required: true
-
     outputs:
 
       configuration:
@@ -65,6 +73,10 @@ on:
 
       dotnet_version:
         value: ${{ inputs.dotnet_version }}
+
+      jfrog_build_name_build:
+        description: The JFrog build name for the 'build' step is suffixed with '-build'.
+        value: ${{ jobs.build.outputs.jfrog_build_name }}
 
       persisted_workspace_artifact_name:
         description: Name of the artifact which contains the persisted workspace directory.
@@ -84,17 +96,18 @@ jobs:
 
     outputs:
       persisted_workspace_artifact_name: ${{ steps.persist-workspace.outputs.artifact_name }}
+      jfrog_build_name: ${{ env.JFROG_CLI_BUILD_NAME }}
 
     env:
       CONFIGURATION: ${{ inputs.configuration }}
       NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
       PROJECTDIRECTORY: ${{ inputs.project_directory }}
-      JFROG_API_KEY: ${{ secrets.jfrog_api_key }}
       JFROG_API_BASE_URL: ${{ inputs.jfrog_api_base_url }}
-      JFROG_API_USERNAME: ${{ inputs.jfrog_api_username }}
-      JFROG_NUGET_FEED_NAME: jfrog-${{ inputs.jfrog_nuget_feed_repo }}
+      JFROG_CLI_BUILD_NAME: "${{ inputs.jfrog_build_name }}-build"
+      JFROG_CLI_BUILD_NUMBER: ${{ inputs.jfrog_build_number }}
+      JFROG_CLI_LOG_LEVEL: DEBUG # JFrog CLI { DEBUG, INFO, WARN, ERROR }
       JFROG_NUGET_FEED_REPO: ${{ inputs.jfrog_nuget_feed_repo }}
-      JFROG_NUGET_FEED_REPO_URL: "${{ inputs.jfrog_api_base_url }}artifactory/api/nuget/v3/${{ inputs.jfrog_nuget_feed_repo }}/index.json"
+      JFROG_OIDC_PROVIDER_NAME: ${{ inputs.jfrog_oidc_provider_name }}
 
     steps:
 
@@ -110,16 +123,16 @@ jobs:
         with:
           name: ${{ env.JFROG_NUGET_FEED_REPO }}
 
+      - name: Validate inputs.jfrog_oidc_provider_name
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        with: # This regex pattern is a bit of a guess
+          regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
+          value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
+
       - name: Validate inputs.project_directory
         uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
-
-      - name: Validate secrets.jfrog_api_key JWT
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
-        with:
-          regex_pattern: '^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$'
-          value: ${{ env.JFROG_API_KEY }}
 
       - name: github context debug information
         working-directory: ./
@@ -130,6 +143,9 @@ jobs:
           echo "github.ref_name=${{ github.ref_name }}"
           echo "github.repository=${{ github.repository }}"
           echo "github.repository_owner=${{ github.repository_owner }}"
+          echo "github.run_id=${{ github.run_id }}"
+          echo "github.run_number=${{ github.run_number }}"
+          echo "github.run_attempt=${{ github.run_attempt }}"
           echo "github.sha=${{ github.sha }}"
 
       - name: Checkout Project
@@ -137,10 +153,28 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      # This creates the setup-jfrog-cli-server server ID
+      - name: Install JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: ${{ env.JFROG_API_BASE_URL }}
+        with:
+          oidc-provider-name: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
+
+      - name: jf config show
+        run: jf config show
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Setup ~/.nuget/packages cache
+        uses: actions/cache@v3
+        with:
+          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
+          path: |
+            ~/.nuget/packages
 
       - run: dotnet nuget list source
 
@@ -150,29 +184,17 @@ jobs:
           echo "$sources"
           echo "$sources" | xargs -I % dotnet nuget remove source %
 
-      - name: dotnet nuget add source JFROG_NUGET_FEED_NAME
-        run: dotnet nuget add source "${JFROG_NUGET_FEED_REPO_URL}" --name "${JFROG_NUGET_FEED_NAME}" --username "${JFROG_API_USERNAME}" --password "${JFROG_API_KEY}" --store-password-in-clear-text
-
       - run: dotnet nuget list source
 
-      - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
-        with:
-          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
-          path: |
-            ~/.nuget/packages
+      - name: Configure .NET / NuGet using JFrog CLI
+        run: jf dotnet-config --server-id-resolve setup-jfrog-cli-server --repo-resolve "${JFROG_NUGET_FEED_REPO}"
 
-      - run: dotnet restore --verbosity=normal
+      - name: .NET Restore using JFrog CLI
+        run: jf dotnet restore
 
       - run: dotnet build --configuration "${CONFIGURATION}"
 
       - run: ls -la
-
-      - name: Persist Workspace
-        id: persist-workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.2
-        with:
-          artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}
 
       - run: ls -la ~/.nuget
 
@@ -180,3 +202,17 @@ jobs:
 
       - run: ls -la ~/.nuget/packages
 
+      - name: Persist Workspace
+        id: persist-workspace
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.9.2
+        with:
+          artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}
+
+      - name: Collect JFrog Build Information
+        run: jf rt build-collect-env "${JFROG_CLI_BUILD_NAME}" "${JFROG_CLI_BUILD_NUMBER}"
+
+      - name: Collect JFrog 'git' Information
+        run: jf rt build-add-git "${JFROG_CLI_BUILD_NAME}" "${JFROG_CLI_BUILD_NUMBER}"
+
+      - name: Push JFrog Build Information
+        run: jf rt build-publish "${JFROG_CLI_BUILD_NAME}" "${JFROG_CLI_BUILD_NUMBER}"

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -1,0 +1,236 @@
+name: Pack (.NET)
+
+# The "jfrog/setup-jfrog-cli" action requires "id-token: write" or else you will get
+# an error about: "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable".
+
+permissions:
+  contents: read
+  id-token: write
+
+on:
+
+  workflow_call:
+
+    inputs:
+
+      artifact_name:
+        required: true
+        type: string
+
+      artifact_retention_days:
+        required: false
+        type: number
+        default: 90
+
+      configuration:
+        required: false
+        type: string
+        default: "Release"
+
+      dotnet_version:
+        required: false
+        type: string
+        default: "6.0"
+
+      jfrog_api_base_url:
+        description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
+        required: true
+        type: string
+
+      jfrog_artifactory_repository:
+        description: 'JFrog Artifactory repository identifier.'
+        required: true
+        type: string
+
+      jfrog_build_name:
+        description: 'JFrog build name.'
+        required: true
+        type: string
+
+      jfrog_build_name_build:
+        description: 'JFrog build name from the build step.  We append that build to the pack step build-info.'
+        required: true
+        type: string
+
+      jfrog_build_number:
+        description: 'JFrog build number. Can be an integer, a semantic version, or a string.'
+        required: true
+        type: string
+
+      jfrog_oidc_provider_name:
+        description: The OIDC Integration Provider Name to use for authentication from the GitHub Action to the JFrog instance.
+        required: true
+        type: string
+
+      persisted_workspace_artifact_name:
+        description: Name of the artifact which contains the persisted workspace directory.
+        required: true
+        type: string
+
+      project_directory:
+        required: false
+        type: string
+        default: "./"
+
+      informational_version:
+        required: true
+        type: string
+
+      version:
+        required: true
+        type: string
+
+    outputs:
+
+      artifact_name:
+        value: ${{ inputs.artifact_name }}
+
+jobs:
+
+  pack:
+    name: Pack (.NET)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+          working-directory: ${{ inputs.project_directory }}
+
+    env:
+      ARTIFACTNAME: ${{ inputs.artifact_name }}
+      ARTIFACTPATHSPEC: "${{ inputs.project_directory }}artifacts/*.*nupkg"
+      ARTIFACTRELATIVEFOLDER: artifacts
+      CONFIGURATION: ${{ inputs.configuration }}
+      JFROG_SERVER_ID: setup-jfrog-cli-server
+      JFROG_API_BASE_URL: ${{ inputs.jfrog_api_base_url }}
+      JFROG_ARTIFACTORY_REPOSITORY: ${{ inputs.jfrog_artifactory_repository }}
+      JFROG_CLI_BUILD_NAME: "${{ inputs.jfrog_build_name }}"
+      JFROG_CLI_BUILD_NAME_BUILD: "${{ inputs.jfrog_build_name_build }}"
+      JFROG_CLI_BUILD_NUMBER: ${{ inputs.jfrog_build_number }}
+      JFROG_CLI_LOG_LEVEL: DEBUG # JFrog CLI { DEBUG, INFO, WARN, ERROR }
+      JFROG_OIDC_PROVIDER_NAME: ${{ inputs.jfrog_oidc_provider_name }}
+      NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
+      PROJECTDIRECTORY: ${{ inputs.project_directory }}
+      INFORMATIONALVERSION: ${{ inputs.informational_version }}
+      VERSION: ${{ inputs.version }}
+
+    steps:
+
+      - name: Validate inputs.artifact_name
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        with:
+          file_name: ${{ env.ARTIFACTNAME }}
+
+      - name: Validate inputs.configuration
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        with:
+          case_sensitive: false
+          regex_pattern: "^debug|release$"
+          value: ${{ env.CONFIGURATION }}
+
+      - name: Validate inputs.project_directory
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        with:
+          path_name: ${{ env.PROJECTDIRECTORY }}
+
+      - name: Validate inputs.informational_version
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        with:
+          version: ${{ env.INFORMATIONALVERSION }}
+
+      - name: Validate inputs.version
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        with:
+          version: ${{ env.VERSION }}
+
+      - name: github context debug information
+        working-directory: ./
+        run: |
+          echo "github.base_ref=${{ github.base_ref }}"
+          echo "github.head_ref=${{ github.head_ref }}"
+          echo "github.ref=${{ github.ref }}"
+          echo "github.ref_name=${{ github.ref_name }}"
+          echo "github.repository=${{ github.repository }}"
+          echo "github.repository_owner=${{ github.repository_owner }}"
+          echo "github.run_id=${{ github.run_id }}"
+          echo "github.run_number=${{ github.run_number }}"
+          echo "github.run_attempt=${{ github.run_attempt }}"
+          echo "github.sha=${{ github.sha }}"
+
+      - name: Checkout Project
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Restore Workspace
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.10.0
+        with:
+          action: retrieve
+          artifact_name: ${{ inputs.persisted_workspace_artifact_name }}
+
+      # This creates the setup-jfrog-cli-server server ID
+      - name: Install JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: ${{ env.JFROG_API_BASE_URL }}
+        with:
+          oidc-provider-name: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
+
+      - name: jf config show
+        run: jf config show
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Setup ~/.nuget/packages cache
+        uses: actions/cache@v3
+        with:
+          key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
+          path: |
+            ~/.nuget/packages
+
+      - run: mkdir -p "${ARTIFACTRELATIVEFOLDER}"
+
+      # TODO: Switch to "jf dotnet pack"
+      - name: dotnet pack
+        run: |
+          jf dotnet pack \
+            --no-build \
+            --include-symbols \
+            --configuration "${CONFIGURATION}" \
+            -p:Version="${VERSION}" \
+            -p:InformationalVersion="${INFORMATIONALVERSION}" \
+            --output "${ARTIFACTRELATIVEFOLDER}"
+
+      - run: ls -l "${ARTIFACTRELATIVEFOLDER}"
+
+      - name: Upload Artifacts
+        id: upload-artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ env.ARTIFACTPATHSPEC }}
+          retention-days: ${{ inputs.artifact_retention_days }}
+          if-no-files-found: error
+
+      - name: Collect JFrog Build Information
+        run: jf rt build-collect-env "${JFROG_CLI_BUILD_NAME}" "${JFROG_CLI_BUILD_NUMBER}"
+
+      - name: Collect JFrog 'git' Information
+        run: jf rt build-add-git "${JFROG_CLI_BUILD_NAME}" "${JFROG_CLI_BUILD_NUMBER}"
+
+      - name: Upload '*.nupkg' files to JFrog Artifactory
+        run: jf rt upload '*.nupkg' "${JFROG_ARTIFACTORY_REPOSITORY}" --fail-no-op --server-id="${JFROG_SERVER_ID}" --build-name="${JFROG_CLI_BUILD_NAME}" --build-number="${JFROG_CLI_BUILD_NUMBER}"
+        working-directory: ${{ env.ARTIFACTRELATIVEFOLDER }}
+        continue-on-error: true
+
+      - name: Upload '*.snupkg' files to JFrog Artifactory
+        run: jf rt upload '*.snupkg' "${JFROG_ARTIFACTORY_REPOSITORY}" --server-id="${JFROG_SERVER_ID}" --build-name="${JFROG_CLI_BUILD_NAME}" --build-number="${JFROG_CLI_BUILD_NUMBER}"
+        working-directory: ${{ env.ARTIFACTRELATIVEFOLDER }}
+        continue-on-error: true
+
+      - name: Append the JFrog "-build" build-info to this build-info
+        run: jf rt build-append "${JFROG_CLI_BUILD_NAME}" "${JFROG_CLI_BUILD_NUMBER}" "${JFROG_CLI_BUILD_NAME_BUILD}" "${JFROG_CLI_BUILD_NUMBER}"
+
+      - name: Push JFrog Build Information
+        run: jf rt build-publish "${JFROG_CLI_BUILD_NAME}" "${JFROG_CLI_BUILD_NUMBER}"


### PR DESCRIPTION
- Move to using OIDC integration with JFrog (BREAKING)
- Stop using JFrog API key authentication (BREAKING)
- Generate JFrog build-info during the steps
- Use the composite/aggregate approach for build-info