### PR TITLE
The JFrog "upload *.nupkg" step should fail if fail

### DIFF
--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -222,7 +222,6 @@ jobs:
       - name: Upload '*.nupkg' files to JFrog Artifactory
         run: jf rt upload '*.nupkg' "${JFROG_ARTIFACTORY_REPOSITORY}" --fail-no-op --server-id="${JFROG_SERVER_ID}" --build-name="${JFROG_CLI_BUILD_NAME}" --build-number="${JFROG_CLI_BUILD_NUMBER}"
         working-directory: ${{ env.ARTIFACTRELATIVEFOLDER }}
-        continue-on-error: true
 
       - name: Upload '*.snupkg' files to JFrog Artifactory
         run: jf rt upload '*.snupkg' "${JFROG_ARTIFACTORY_REPOSITORY}" --server-id="${JFROG_SERVER_ID}" --build-name="${JFROG_CLI_BUILD_NAME}" --build-number="${JFROG_CLI_BUILD_NUMBER}"


### PR DESCRIPTION
Putting "continue-on-error: true" on the step that uploads ".nupkg" files to JFrog Artifactory should not have been added.

If we fail to upload any packages to Artifactory, the job should fail.