### PR TITLE
Pass jfrog_nuget_feed_repo, etc. down from parent

### DIFF
--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -63,6 +63,11 @@ on:
         default: ERROR
         type: string
 
+      jfrog_nuget_feed_repo:
+        description: The 'virtual' JFrog Artifactory repository identifier for NuGet package retrieval.
+        required: true
+        type: string
+
       jfrog_oidc_provider_name:
         description: The OIDC Integration Provider Name to use for authentication from the GitHub Action to the JFrog instance.
         required: true
@@ -112,6 +117,7 @@ jobs:
       JFROG_CLI_BUILD_NAME_BUILD: "${{ inputs.jfrog_build_name_build }}"
       JFROG_CLI_BUILD_NUMBER: ${{ inputs.jfrog_build_number }}
       JFROG_CLI_LOG_LEVEL: ${{ inputs.jfrog_cli_log_level }}
+      JFROG_NUGET_FEED_REPO: ${{ inputs.jfrog_nuget_feed_repo }}
       JFROG_OIDC_PROVIDER_NAME: ${{ inputs.jfrog_oidc_provider_name }}
       NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
       PROJECTDIRECTORY: ${{ inputs.project_directory }}
@@ -195,8 +201,20 @@ jobs:
           path: |
             ~/.nuget/packages
 
+      - run: dotnet nuget list source
+
+      - name: Remove any pre-defined NuGet sources
+        run: |
+          sources=$(dotnet nuget list source | grep '\[Enabled\]' | awk '{print $2}')
+          echo "$sources"
+          echo "$sources" | xargs -I % dotnet nuget remove source %
+
+      - run: dotnet nuget list source
+
       - name: Configure .NET / NuGet using JFrog CLI
         run: jf dotnet-config --global --server-id-resolve setup-jfrog-cli-server --repo-resolve "${JFROG_NUGET_FEED_REPO}"
+
+      - run: dotnet nuget list source
 
       - run: mkdir -p "${ARTIFACTRELATIVEFOLDER}"
 

--- a/.github/workflows/dotnet-packages-pr-build-jfrog.yml
+++ b/.github/workflows/dotnet-packages-pr-build-jfrog.yml
@@ -147,6 +147,7 @@ jobs:
       jfrog_build_name: ${{ inputs.jfrog_build_name }}
       jfrog_build_name_build: ${{ needs.build.outputs.jfrog_build_name_build }}
       jfrog_build_number: ${{ needs.version.outputs.version }}
+      jfrog_nuget_feed_repo: ${{ inputs.jfrog_nuget_feed_repo }}
       jfrog_oidc_provider_name: ${{ inputs.jfrog_oidc_provider_name }}
       persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
       project_directory: ${{ needs.build.outputs.project_directory }}

--- a/.github/workflows/dotnet-private-packages-release-build-jfrog.yml
+++ b/.github/workflows/dotnet-private-packages-release-build-jfrog.yml
@@ -26,6 +26,12 @@ on:
         default: 11435
         type: number
 
+      dotnet_restore_verbosity:
+        description: 'The dotnet restore "--verbosity=" flag.  Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. The default is minimal.'
+        required: false
+        type: string
+        default: minimal
+
       dotnet_version:
         required: false
         type: string
@@ -39,6 +45,12 @@ on:
       jfrog_api_base_url:
         description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
         required: true
+        type: string
+
+      jfrog_cli_log_level:
+        description: 'Set the log level for the JFrog CLI. Default is ERROR. Values are: (DEBUG, INFO, WARN, ERROR).'
+        required: false
+        default: ERROR
         type: string
 
       jfrog_oidc_provider_name:
@@ -84,10 +96,12 @@ jobs:
     uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.14.1
     #uses: ./.github/workflows/dotnet-build-jfrog.yml
     with:
+      dotnet_restore_verbosity: ${{ inputs.dotnet_restore_verbosity }}
       dotnet_version: ${{ inputs.dotnet_version }}
       jfrog_api_base_url: ${{ inputs.jfrog_api_base_url }}
       jfrog_build_name: ${{ inputs.jfrog_build_name }}
       jfrog_build_number: ${{ needs.version.outputs.version }}
+      jfrog_cli_log_level: ${{ inputs.jfrog_cli_log_level }}
       jfrog_nuget_feed_repo: ${{ inputs.jfrog_nuget_feed_repo }}
       jfrog_oidc_provider_name: ${{ inputs.jfrog_oidc_provider_name }}
       project_directory: ${{ inputs.project_directory }}
@@ -136,6 +150,7 @@ jobs:
       jfrog_build_name: ${{ inputs.jfrog_build_name }}
       jfrog_build_name_build: ${{ needs.build.outputs.jfrog_build_name_build }}
       jfrog_build_number: ${{ needs.version.outputs.version }}
+      jfrog_nuget_feed_repo: ${{ inputs.jfrog_nuget_feed_repo }}
       jfrog_oidc_provider_name: ${{ inputs.jfrog_oidc_provider_name }}
       persisted_workspace_artifact_name: ${{ needs.build.outputs.persisted_workspace_artifact_name }}
       project_directory: ${{ needs.build.outputs.project_directory }}


### PR DESCRIPTION
- 'pack' now needs 'jfrog_nuget_feed_repo'
- Update the Release build to look like the PR build workflow