### PR TITLE
Upgrade all uses of regex-validator to v1.15.0

### DIFF
--- a/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
+++ b/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
@@ -107,12 +107,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -125,31 +125,31 @@ jobs:
     steps:
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_nuget_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.14.1
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.15.0
         with:
           name: ${{ env.JFROG_NUGET_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -67,14 +67,14 @@ jobs:
     steps:
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/dotnet-frogbot-private-repo-scan.yml
+++ b/.github/workflows/dotnet-frogbot-private-repo-scan.yml
@@ -76,24 +76,24 @@ jobs:
     steps:
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_nuget_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.14.1
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.15.0
         with:
           name: ${{ env.JFROG_NUGET_FEED_REPO }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate secrets.jfrog_api_key JWT
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           regex_pattern: '^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$'
           value: ${{ env.JFROG_API_KEY }}

--- a/.github/workflows/dotnet-jfrog-xray-scan.yml
+++ b/.github/workflows/dotnet-jfrog-xray-scan.yml
@@ -62,18 +62,18 @@ jobs:
     steps:
 
       - name: Validate secrets.jfrog_api_key
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           regex_pattern: '^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$'
           value: ${{ secrets.jfrog_api_key }}
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.report_artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.REPORTARTIFACTNAME }}
 

--- a/.github/workflows/dotnet-npm-astro-build-test-publish.yml
+++ b/.github/workflows/dotnet-npm-astro-build-test-publish.yml
@@ -177,78 +177,78 @@ jobs:
     steps:
 
       - name: Validate inputs.publish_artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.PUBLISHARTIFACTNAME }}
 
       - name: Validate inputs.test_results_artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.TESTRESULTSARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.npm_package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.NPMPACKAGEJSONFILENAME }}
 
       - name: Validate inputs.npm_project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.NPMPROJECTDIRECTORY }}
 
       - name: Validate inputs.publish_working_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PUBLISHWORKINGDIRECTORY }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.git_hash
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           value: ${{ env.GIT_HASH }}
           regex_pattern: '^([a-fA-F0-9]{40})$'
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.VERSION }}
 
       - name: Validate inputs.astro_target_brand
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           value: ${{ env.TARGET_BRAND }}
           regex_pattern: '^(standard|whitelabel)$'
 
       - name: Validate inputs.astro_target_environment
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           value: ${{ env.TARGET_ENVIRONMENT }}
           regex_pattern: '^(development|staging|production)$'
 
       - name: Validate inputs.astro_target_configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           value: ${{ env.TARGET_CONFIGURATION }}
           regex_pattern: '^(release|debug)$'
 
       - name: Validate ZIPFILENAME
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.8.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ZIPFILENAME }}
 

--- a/.github/workflows/dotnet-npm-build.yml
+++ b/.github/workflows/dotnet-npm-build.yml
@@ -101,24 +101,24 @@ jobs:
     steps:
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.npm_package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.NPMPACKAGEJSONFILENAME }}
 
       - name: Validate inputs.npm_project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.NPMPROJECTDIRECTORY }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/dotnet-npm-test.yml
+++ b/.github/workflows/dotnet-npm-test.yml
@@ -166,34 +166,34 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.npm_package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.NPMPACKAGEJSONFILENAME }}
 
       - name: Validate inputs.npm_project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.NPMPROJECTDIRECTORY }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate RIMDEVTESTS__SQL__PASSWORD (must be 8-250 chars)
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         if: inputs.docker_mssql_image != ''
         with:
           value: ${{ env.RIMDEVTESTS__SQL__PASSWORD }}

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -128,35 +128,35 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.VERSION }}
 

--- a/.github/workflows/dotnet-pack.yml
+++ b/.github/workflows/dotnet-pack.yml
@@ -73,29 +73,29 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.VERSION }}
 

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -141,45 +141,45 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.publish_working_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PUBLISH_WORKING_DIRECTORY }}
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.VERSION }}
 
       - name: Validate ZIPFILENAME
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ZIPFILENAME }}
 

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -88,39 +88,39 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.publish_working_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PUBLISH_WORKING_DIRECTORY }}
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.VERSION }}
 
       - name: Validate ZIPFILENAME
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ZIPFILENAME }}
 

--- a/.github/workflows/dotnet-push-github.yml
+++ b/.github/workflows/dotnet-push-github.yml
@@ -35,12 +35,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ inputs.artifact_name }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ inputs.project_directory }}
 

--- a/.github/workflows/dotnet-push-jfrog-artifactory.yml
+++ b/.github/workflows/dotnet-push-jfrog-artifactory.yml
@@ -67,22 +67,22 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ inputs.artifact_name }}
 
       - name: Validate inputs.jfrog_artifactory_repository
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.14.1
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.15.0
         with:
           name: ${{ env.JFROG_ARTIFACTORY_REPOSITORY }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ inputs.project_directory }}
 
       - name: Validate secrets.jfrog_api_key
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           regex_pattern: '^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$'
           value: ${{ secrets.jfrog_api_key }}

--- a/.github/workflows/dotnet-push-myget.yml
+++ b/.github/workflows/dotnet-push-myget.yml
@@ -43,12 +43,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ inputs.artifact_name }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ inputs.project_directory }}
 

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -201,41 +201,41 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_nuget_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.14.1
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.15.0
         with:
           name: ${{ env.JFROG_NUGET_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate RIMDEVTESTS__SQL__PASSWORD (must be 8-250 chars)
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         if: inputs.docker_mssql_image != ''
         with:
           value: ${{ env.RIMDEVTESTS__SQL__PASSWORD }}

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -146,24 +146,24 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate RIMDEVTESTS__SQL__PASSWORD (must be 8-250 chars)
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         if: inputs.docker_mssql_image != ''
         with:
           value: ${{ env.RIMDEVTESTS__SQL__PASSWORD }}

--- a/.github/workflows/extract-version-from-npm-package-json.yml
+++ b/.github/workflows/extract-version-from-npm-package-json.yml
@@ -90,12 +90,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/jfrog-xray-audit.yml
+++ b/.github/workflows/jfrog-xray-audit.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
@@ -89,12 +89,12 @@ jobs:
 #TODO: Validate inputs.jfrog_xray_watch_list
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.report_artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.10.0
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.REPORTARTIFACTNAME }}
 

--- a/.github/workflows/npm-build-test-public.yml
+++ b/.github/workflows/npm-build-test-public.yml
@@ -80,12 +80,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -87,12 +87,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -75,12 +75,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/npm-create-version-tag.yml
+++ b/.github/workflows/npm-create-version-tag.yml
@@ -88,27 +88,27 @@ jobs:
     steps:
 
       - name: Validate inputs.npm_scope
-        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.15.0
         with:
           npm_scope: ${{ env.NPMSCOPE }}
 
       - name: Validate inputs.npm_package_name
-        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.15.0
         with:
           package_name: ${{ env.NPMPACKAGENAME }}
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.NPMVERSION }}
 

--- a/.github/workflows/npm-pack.yml
+++ b/.github/workflows/npm-pack.yml
@@ -88,27 +88,27 @@ jobs:
     steps:
 
       - name: Validate inputs.npm_scope
-        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.15.0
         with:
           npm_scope: ${{ env.NPMSCOPE }}
 
       - name: Validate inputs.npm_package_name
-        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.15.0
         with:
           package_name: ${{ env.NPMPACKAGENAME }}
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.NPMVERSION }}
 

--- a/.github/workflows/npm-publish-to-github-packages.yml
+++ b/.github/workflows/npm-publish-to-github-packages.yml
@@ -37,12 +37,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.artifact_file_path
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTFILEPATH }}          
 

--- a/.github/workflows/npm-publish-to-myget.yml
+++ b/.github/workflows/npm-publish-to-myget.yml
@@ -42,12 +42,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.artifact_file_path
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTFILEPATH }} 
 

--- a/.github/workflows/npm-publish-to-npmjs-org.yml
+++ b/.github/workflows/npm-publish-to-npmjs-org.yml
@@ -48,12 +48,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.artifact_file_path
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
         with:
           file_name: ${{ env.ARTIFACTFILEPATH }} 
 

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.9.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/actions/attach-artifact-to-release/action.yml
+++ b/actions/attach-artifact-to-release/action.yml
@@ -32,31 +32,31 @@ runs:
   steps:
 
     - name: Validate inputs.artifact_name
-      uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
       env:
         ARTIFACTNAME: ${{ inputs.artifact_name }}
       with:
         file_name: ${{ env.ARTIFACTNAME }}
 
     - name: Validate inputs.artifact_file_path
-      uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
       env:
         ARTIFACTFILEPATH: ${{ inputs.artifact_file_path }}
       with:
         file_name: ${{ env.ARTIFACTFILEPATH }}
 
     - name: Validate inputs.github_repository
-      uses: ritterim/public-github-actions/actions/github-org-repository-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/github-org-repository-validator@v1.15.0
       with:
         github_repository: ${{ inputs.github_repository }}
 
     - name: Validate inputs.github_token
-      uses: ritterim/public-github-actions/actions/github-token-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/github-token-validator@v1.15.0
       with:
         token: ${{ inputs.github_token }}
 
     - name: Validate inputs.version_tag
-      uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
       env:
         VERSIONTAG: ${{ inputs.version_tag }}
       with:

--- a/actions/calculate-version-from-txt-using-github-run-id/action.yml
+++ b/actions/calculate-version-from-txt-using-github-run-id/action.yml
@@ -63,7 +63,7 @@ runs:
       shell: bash
 
     - name: Validate inputs.github_run_id_baseline
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.github_run_id_baseline }}
         regex_pattern: '^[0-9]{10,12}$'    

--- a/actions/create-github-release/action.yml
+++ b/actions/create-github-release/action.yml
@@ -28,17 +28,17 @@ runs:
   steps:
 
     - name: Validate inputs.github_repository
-      uses: ritterim/public-github-actions/actions/github-org-repository-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/github-org-repository-validator@v1.15.0
       with:
         github_repository: ${{ inputs.github_repository }}
 
     - name: Validate inputs.github_token
-      uses: ritterim/public-github-actions/actions/github-token-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/github-token-validator@v1.15.0
       with:
         token: ${{ inputs.github_token }}
 
     - name: Validate inputs.version_tag
-      uses: ritterim/public-github-actions/actions/version-number-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
       env:
         VERSIONTAG: ${{ inputs.version_tag }}
       with:

--- a/actions/file-name-validator/action.yml
+++ b/actions/file-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.file_name }}
         regex_pattern: '^[A-Za-z0-9_\.\+-]{3,70}$'

--- a/actions/file-path-name-validator/action.yml
+++ b/actions/file-path-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.file_path_name }}
         regex_pattern: '^[A-Za-z0-9_\.\+\/-]{2,90}$'

--- a/actions/github-org-repository-validator/action.yml
+++ b/actions/github-org-repository-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.github_repository }}
         regex_pattern: '^[a-zA-Z0-9-]{1,25}\/[a-zA-Z0-9-]{1,50}$'

--- a/actions/github-token-validator/action.yml
+++ b/actions/github-token-validator/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
 
     - name: Validate token
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.token }}
         regex_pattern: '^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$'

--- a/actions/guid-validator/action.yml
+++ b/actions/guid-validator/action.yml
@@ -26,7 +26,7 @@ runs:
     # FUTURE: Allow curly braces with a boolean input option using '^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$'
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.guid }}
         regex_pattern: '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'

--- a/actions/jfrog-artifactory-repository-name-validator/action.yml
+++ b/actions/jfrog-artifactory-repository-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.name }}
         regex_pattern: '^[A-Za-z0-9\-]{5,55}$'

--- a/actions/npm-config-github-packages-repository/action.yml
+++ b/actions/npm-config-github-packages-repository/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
 
     - name: Validate inputs.npm_scope
-      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.15.0
       with:
         npm_scope: ${{ inputs.npm_scope }}
 

--- a/actions/npm-config-myget-packages-repository/action.yml
+++ b/actions/npm-config-myget-packages-repository/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate inputs.npm_scope
-      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.15.0
       with:
         npm_scope: ${{ inputs.npm_scope }}
 

--- a/actions/npm-config-npmjs-org-registry/action.yml
+++ b/actions/npm-config-npmjs-org-registry/action.yml
@@ -24,12 +24,12 @@ runs:
   steps:
 
     - name: Validate inputs.npm_scope
-      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.15.0
       with:
         npm_scope: ${{ inputs.npm_scope }}
 
     - name: Validate inputs.npmjs_org_api_key
-      uses: ritterim/public-github-actions/actions/npmjs-access-token-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/npmjs-access-token-validator@v1.15.0
       with:
         token: ${{ inputs.npmjs_org_api_key }}
 

--- a/actions/npm-package-name-validator/action.yml
+++ b/actions/npm-package-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.package_name }}
         regex_pattern: '^[a-z0-9\-]{5,40}$'

--- a/actions/npm-package-scope-validator/action.yml
+++ b/actions/npm-package-scope-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.npm_scope }}
         regex_pattern: '^[a-z0-9\-]{5,25}$'

--- a/actions/npmjs-access-token-validator/action.yml
+++ b/actions/npmjs-access-token-validator/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.token }}
         regex_pattern: '^(npm_[A-Za-z0-9]{36})$'

--- a/actions/path-name-validator/action.yml
+++ b/actions/path-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.path_name }}
         regex_pattern: '^[A-Za-z0-9_\.\+\/-]{1,70}\/$'

--- a/actions/version-number-major-minor-validator/action.yml
+++ b/actions/version-number-major-minor-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         value: ${{ inputs.version }}
         regex_pattern: '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)?$'

--- a/actions/version-number-validator/action.yml
+++ b/actions/version-number-validator/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
 
     - name: Validate with 'v' prefix
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       if: inputs.allow_v_prefix == 'true'
       with:
         value: ${{ inputs.version }}
@@ -38,7 +38,7 @@ runs:
         error_if_not_valid: ${{ inputs.error_if_not_valid }}
 
     - name: Validate without 'v' prefix
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       if: inputs.allow_v_prefix != 'true'
       with:
         value: ${{ inputs.version }}

--- a/forks/persist-workspace/action.yml
+++ b/forks/persist-workspace/action.yml
@@ -50,13 +50,13 @@ runs:
   steps:
 
     - name: Validate inputs.artifact_name
-      uses: ritterim/public-github-actions/actions/file-name-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
       with:
         file_name: ${{ inputs.artifact_name }}
         required: false
 
     - name: Validate inputs.artifact_name_suffix
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.9.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.15.0
       with:
         regex_pattern: '^[a-zA-Z0-9]{2,40}$'
         required: false


### PR DESCRIPTION
- Switches to Node v20 (from Node v16)
- Upgrades dev dependencies (dependabot alerts)
- Addresses some other minor vulnerabilities