### PR TITLE
Upgrade to actions/checkout@v4

### DIFF
--- a/.github/workflows/calculate-version-from-txt-using-github-run-id.yml
+++ b/.github/workflows/calculate-version-from-txt-using-github-run-id.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
+++ b/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
@@ -124,7 +124,7 @@ jobs:
           echo "github.ref=${{ github.ref }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -168,7 +168,7 @@ jobs:
           echo "github.sha=${{ github.sha }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -86,7 +86,7 @@ jobs:
           echo "github.ref=${{ github.ref }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/dotnet-frogbot-private-repo-scan.yml
+++ b/.github/workflows/dotnet-frogbot-private-repo-scan.yml
@@ -110,7 +110,7 @@ jobs:
           echo "github.sha=${{ github.sha }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/dotnet-npm-astro-build-test-publish.yml
+++ b/.github/workflows/dotnet-npm-astro-build-test-publish.yml
@@ -260,7 +260,7 @@ jobs:
           echo "github.ref=${{ github.ref }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           lfs: true

--- a/.github/workflows/dotnet-npm-build.yml
+++ b/.github/workflows/dotnet-npm-build.yml
@@ -130,7 +130,7 @@ jobs:
           echo "github.ref=${{ github.ref }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -175,7 +175,7 @@ jobs:
           echo "github.sha=${{ github.sha }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -198,7 +198,7 @@ jobs:
           echo "github.sha=${{ github.sha }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -139,7 +139,7 @@ jobs:
           echo "github.sha=${{ github.sha }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/dotnet-push-jfrog-artifactory.yml
+++ b/.github/workflows/dotnet-push-jfrog-artifactory.yml
@@ -99,7 +99,7 @@ jobs:
           echo "github.sha=${{ github.sha }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -261,7 +261,7 @@ jobs:
         run: echo "The 'inputs.run_tests' value is FALSE, skipping tests!"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/extract-version-from-npm-package-json.yml
+++ b/.github/workflows/extract-version-from-npm-package-json.yml
@@ -100,7 +100,7 @@ jobs:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/jfrog-publish-aggregate-build-info.yml
+++ b/.github/workflows/jfrog-publish-aggregate-build-info.yml
@@ -121,7 +121,7 @@ jobs:
           echo "github.sha=${{ github.sha }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/npm-build-test-public.yml
+++ b/.github/workflows/npm-build-test-public.yml
@@ -97,7 +97,7 @@ jobs:
           echo "github.ref=${{ github.ref }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/npm-build-test-publish.yml
+++ b/.github/workflows/npm-build-test-publish.yml
@@ -178,7 +178,7 @@ jobs:
           echo "github.ref=${{ github.ref }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           lfs: true

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -104,7 +104,7 @@ jobs:
           echo "github.ref=${{ github.ref }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -92,7 +92,7 @@ jobs:
           echo "github.ref=${{ github.ref }}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/npm-create-version-tag.yml
+++ b/.github/workflows/npm-create-version-tag.yml
@@ -119,7 +119,7 @@ jobs:
           echo "HEADCOMMITTITLE=${HEADCOMMITTITLE}" >> $GITHUB_ENV
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/verify-tag-is-on-allowed-branch.yml
+++ b/.github/workflows/verify-tag-is-on-allowed-branch.yml
@@ -113,7 +113,7 @@ jobs:
           echo "}"
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
 

--- a/actions/calculate-version-from-txt-using-github-run-id/README.md
+++ b/actions/calculate-version-from-txt-using-github-run-id/README.md
@@ -36,7 +36,7 @@ Note that you *must* have a `version.txt` file in the root of the repository wit
     steps:
 
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 

--- a/forks/persist-workspace/.github/workflows/test-with-name.yml
+++ b/forks/persist-workspace/.github/workflows/test-with-name.yml
@@ -7,7 +7,7 @@ jobs:
   init:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
       - name: First step
         run: echo "Init is ready"

--- a/forks/persist-workspace/.github/workflows/test.yml
+++ b/forks/persist-workspace/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
   init:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
       - name: First step
         run: echo "Init is ready"

--- a/forks/persist-workspace/README.md
+++ b/forks/persist-workspace/README.md
@@ -20,7 +20,7 @@ jobs:
   init:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
       - name: Install dependencies
         run: npm install
@@ -41,7 +41,7 @@ jobs:
   init:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
       - name: Install dependencies
         run: npm install
@@ -75,7 +75,7 @@ jobs:
   init:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
The older v3 uses Node v16 which is deprecated
and causes warnings on the GitHub Actions
run.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/