### PR TITLE
Add PUBLISHARTIFACTDIRECTORY and version.json

### DIFF
--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -134,6 +134,7 @@ jobs:
       NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
       PROJECTDIRECTORY: ${{ inputs.project_directory }}
       PUBLISH_WORKING_DIRECTORY: ${{ inputs.publish_working_directory }}
+      PUBLISHARTIFACTDIRECTORY: app/
       INFORMATIONALVERSION: ${{ inputs.informational_version }}
       VERSION: ${{ inputs.version }}
       ZIPFILENAME: "${{ inputs.artifact_name }}.zip"
@@ -177,6 +178,11 @@ jobs:
         uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.VERSION }}
+
+      - name: Validate PUBLISHARTIFACTDIRECTORY
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
+        with:
+          path_name: ${{ env.PUBLISHARTIFACTDIRECTORY }}
 
       - name: Validate ZIPFILENAME
         uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
@@ -249,8 +255,9 @@ jobs:
 
       - run: dotnet nuget list source
 
-      - run: mkdir -p 'app'
+      - name: mkdir -p $PUBLISHARTIFACTDIRECTORY
         working-directory: ${{ inputs.publish_working_directory }}
+        run: mkdir -p "${PUBLISHARTIFACTDIRECTORY}"
 
       - name: dotnet publish
         working-directory: ${{ inputs.publish_working_directory }}
@@ -260,26 +267,47 @@ jobs:
             --configuration "${CONFIGURATION}" \
             -p:Version="${VERSION}" \
             -p:InformationalVersion="${INFORMATIONALVERSION}" \
-            --property:PublishDir=app
+            --property:PublishDir="${PUBLISHARTIFACTDIRECTORY}"
 
       - name: Create githash.txt file
         working-directory: ${{ inputs.publish_working_directory }}
         run: |
           PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}
           GH_SHA="${PULL_REQUEST_HEAD_SHA:-${GITHUB_SHA:-ERROR}}"
-          echo $GH_SHA > app/githash.txt
+          echo $GH_SHA > "${PUBLISHARTIFACTDIRECTORY}githash.txt"
+          cat "${PUBLISHARTIFACTDIRECTORY}githash.txt"
 
-      - run: cat app/githash.txt
+      - name: Create version.json file
         working-directory: ${{ inputs.publish_working_directory }}
+        run: |
+          BUILDDATE=$(date -u -Idate)
+          echo "BUILDDATE=$BUILDDATE"
+          BUILDTIMESTAMP=$(date -u -Iseconds)
+          echo "BUILDTIMESTAMP=$BUILDTIMESTAMP"
+          PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          GH_SHA="${PULL_REQUEST_HEAD_SHA:-${GITHUB_SHA:-ERROR}}"
+          echo "GH_SHA=$GH_SHA"
+          BODY=$(jq --null-input \
+            --arg buildDate "$BUILDDATE" \
+            --arg buildTimestamp "$BUILDTIMESTAMP" \
+            --arg gitHash "$GH_SHA" \
+            --arg informationalVersion "$INFORMATIONALVERSION" \
+            --arg version "$VERSION" \
+            '{"buildDate": $buildDate, "buildTimestamp": $buildTimestamp, "gitHash": $gitHash, "informationalVersion": $informationalVersion, "version": $version}' \
+            )
+          mkdir -p "${PUBLISHARTIFACTDIRECTORY}_version"
+          echo "$BODY" > "${PUBLISHARTIFACTDIRECTORY}version.json"
+          cat "${PUBLISHARTIFACTDIRECTORY}version.json"
 
-      - run: ls -lR 'app'
+      - name: ls -lR $PUBLISHARTIFACTDIRECTORY
         working-directory: ${{ inputs.publish_working_directory }}
+        run: ls -lR "${PUBLISHARTIFACTDIRECTORY}"
 
       - run: mkdir -p 'output'
         working-directory: ${{ inputs.publish_working_directory }}
 
       - name: Create Release Zip File
-        working-directory: "${{ inputs.publish_working_directory }}app"
+        working-directory: "${{ inputs.publish_working_directory }}${{ env.PUBLISHARTIFACTDIRECTORY }}"
         run: |
           zip -v -r \
             "../output/${ZIPFILENAME}" \

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -81,6 +81,7 @@ jobs:
       NUGETHASHFILES: "${{ inputs.project_directory }}**/*.csproj"
       PROJECTDIRECTORY: ${{ inputs.project_directory }}
       PUBLISH_WORKING_DIRECTORY: ${{ inputs.publish_working_directory }}
+      PUBLISHARTIFACTDIRECTORY: app/
       INFORMATIONALVERSION: ${{ inputs.informational_version }}
       VERSION: ${{ inputs.version }}
       ZIPFILENAME: "${{ inputs.artifact_name }}.zip"
@@ -118,6 +119,11 @@ jobs:
         uses: ritterim/public-github-actions/actions/version-number-validator@v1.15.0
         with:
           version: ${{ env.VERSION }}
+
+      - name: Validate PUBLISHARTIFACTDIRECTORY
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.15.0
+        with:
+          path_name: ${{ env.PUBLISHARTIFACTDIRECTORY }}
 
       - name: Validate ZIPFILENAME
         uses: ritterim/public-github-actions/actions/file-name-validator@v1.15.0
@@ -166,8 +172,9 @@ jobs:
 
       - run: dotnet nuget list source
 
-      - run: mkdir -p 'app'
+      - name: mkdir -p $PUBLISHARTIFACTDIRECTORY
         working-directory: ${{ inputs.publish_working_directory }}
+        run: mkdir -p "${PUBLISHARTIFACTDIRECTORY}"
 
       - name: dotnet publish
         working-directory: ${{ inputs.publish_working_directory }}
@@ -177,26 +184,47 @@ jobs:
             --configuration "${CONFIGURATION}" \
             -p:Version="${VERSION}" \
             -p:InformationalVersion="${INFORMATIONALVERSION}" \
-            --property:PublishDir=app
+            --property:PublishDir="${PUBLISHARTIFACTDIRECTORY}"
 
       - name: Create githash.txt file
         working-directory: ${{ inputs.publish_working_directory }}
         run: |
           PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}
           GH_SHA="${PULL_REQUEST_HEAD_SHA:-${GITHUB_SHA:-ERROR}}"
-          echo $GH_SHA > app/githash.txt
+          echo $GH_SHA > "${PUBLISHARTIFACTDIRECTORY}githash.txt"
+          cat "${PUBLISHARTIFACTDIRECTORY}githash.txt"
 
-      - run: cat app/githash.txt
+      - name: Create version.json file
         working-directory: ${{ inputs.publish_working_directory }}
+        run: |
+          BUILDDATE=$(date -u -Idate)
+          echo "BUILDDATE=$BUILDDATE"
+          BUILDTIMESTAMP=$(date -u -Iseconds)
+          echo "BUILDTIMESTAMP=$BUILDTIMESTAMP"
+          PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          GH_SHA="${PULL_REQUEST_HEAD_SHA:-${GITHUB_SHA:-ERROR}}"
+          echo "GH_SHA=$GH_SHA"
+          BODY=$(jq --null-input \
+            --arg buildDate "$BUILDDATE" \
+            --arg buildTimestamp "$BUILDTIMESTAMP" \
+            --arg gitHash "$GH_SHA" \
+            --arg informationalVersion "$INFORMATIONALVERSION" \
+            --arg version "$VERSION" \
+            '{"buildDate": $buildDate, "buildTimestamp": $buildTimestamp, "gitHash": $gitHash, "informationalVersion": $informationalVersion, "version": $version}' \
+            )
+          mkdir -p "${PUBLISHARTIFACTDIRECTORY}_version"
+          echo "$BODY" > "${PUBLISHARTIFACTDIRECTORY}version.json"
+          cat "${PUBLISHARTIFACTDIRECTORY}version.json"
 
-      - run: ls -lR 'app'
+      - name: ls -lR $PUBLISHARTIFACTDIRECTORY
         working-directory: ${{ inputs.publish_working_directory }}
+        run: ls -lR "${PUBLISHARTIFACTDIRECTORY}"
 
       - run: mkdir -p 'output'
         working-directory: ${{ inputs.publish_working_directory }}
 
       - name: Create Release Zip File
-        working-directory: "${{ inputs.publish_working_directory }}app"
+        working-directory: "${{ inputs.publish_working_directory }}${{ env.PUBLISHARTIFACTDIRECTORY }}"
         run: |
           zip -v -r \
             "../output/${ZIPFILENAME}" \


### PR DESCRIPTION
Create a version.json file with information about the build such as git hash, UTC date/time, version and the informational version string.  This is similar to the git_hash.txt file that we created before but gives more context.

```
{
  "buildDate": "2024-04-18",
  "buildTimestamp": "2024-04-18T15:42:36+00:00",
  "gitHash": "2604807a5d98ececf4438e0aea3b31dd0ba8e476",
  "informationalVersion": "1.1.14-alpha260.1+2604807a",
  "version": "1.1.14-alpha260.1"
}
```