### PR TITLE
Upgrade persist-workspace to upload-artifact@v4

### DIFF
--- a/forks/persist-workspace/action.yml
+++ b/forks/persist-workspace/action.yml
@@ -103,7 +103,7 @@ runs:
 
     - name: Upload the workspace artifact
       if: ${{ inputs.action == 'persist' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACTNAME }}
         path: tmp-persisted-workspace/${{ env.TGZFILENAME }}


### PR DESCRIPTION
Note that under v3, you could upload multiple files to the same artifact name.  With v4, that is no longer possible.

That should not be a problem for persist-workspace as you shouldn't be uploading additional files to the workspace file artifact name.

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact