### PR TITLE
Add ability to run tests in larger instance

### DIFF
--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -83,6 +83,11 @@ on:
         type: string
         default: "6.0"
 
+      github_job_runner_spec:
+        description: Which GitHub Runner to use.  Default is 'ubuntu-latest'.
+        type: string
+        default: "ubuntu-latest"
+
       jfrog_api_base_url:
         description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
         required: true
@@ -140,7 +145,7 @@ jobs:
 
   tests:
     name: Test (.NET)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.github_job_runner_spec }}
     defaults:
       run:
           working-directory: ${{ inputs.project_directory }}

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -76,6 +76,11 @@ on:
         type: string
         default: "6.0"
 
+      github_job_runner_spec:
+        description: Which GitHub Runner to use.  Default is 'ubuntu-latest'.
+        type: string
+        default: "ubuntu-latest"
+
       persisted_workspace_artifact_name:
         description: Name of the artifact which contains the persisted workspace directory.
         required: true
@@ -96,7 +101,7 @@ jobs:
 
   tests:
     name: Test (.NET)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.github_job_runner_spec }}
     defaults:
       run:
           working-directory: ${{ inputs.project_directory }}


### PR DESCRIPTION
Add the "github_job_runner_spec" input which defaults to 'ubuntu-latest'.  This allows the caller to specify a larger instance if needed for tests.

(We have not yet needed a larger runner for other workflows.)