### PR TITLE
Upgrade persist-workspace to download-artifact@v4 (bug fix)

### DIFF
--- a/forks/persist-workspace/action.yml
+++ b/forks/persist-workspace/action.yml
@@ -119,7 +119,7 @@ runs:
 
     - name: Retrieve workspace
       if: ${{ inputs.action == 'retrieve' }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ env.ARTIFACTNAME }}
 


### PR DESCRIPTION
This is a bug fix for 1.15.1 -- as persist-workspace 1.15.1 didn't upgrade both the upload and download actions to the same major version.