### PR TITLE
Upgrade Azure Zip Deploy to use azure/login@v2

### DIFF
--- a/.github/workflows/deploy-zip-to-azure-webapps.yml
+++ b/.github/workflows/deploy-zip-to-azure-webapps.yml
@@ -49,7 +49,7 @@ jobs:
 
       - run: ls -la
 
-      - uses: azure/login@v1
+      - uses: azure/login@v2
         with:
           client-id: ${{ vars.ARTIFACT_DEPLOYER_AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.ARTIFACT_DEPLOYER_AZURE_TENANT_ID }}


### PR DESCRIPTION
https://github.com/Azure/login/releases

Upgrades from Node v16 to Node v20.  I'm not seeing any other cautions about upgrading from v1 to v2.