### PR TITLE
Upgrade to actions/setup-dotnet@v4

### DIFF
--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -184,7 +184,7 @@ jobs:
         run: jf config show
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -91,7 +91,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json

--- a/.github/workflows/dotnet-frogbot-private-repo-scan.yml
+++ b/.github/workflows/dotnet-frogbot-private-repo-scan.yml
@@ -115,7 +115,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 

--- a/.github/workflows/dotnet-npm-astro-build-test-publish.yml
+++ b/.github/workflows/dotnet-npm-astro-build-test-publish.yml
@@ -267,7 +267,7 @@ jobs:
           lfs: true
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json

--- a/.github/workflows/dotnet-npm-build.yml
+++ b/.github/workflows/dotnet-npm-build.yml
@@ -135,7 +135,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json

--- a/.github/workflows/dotnet-npm-test.yml
+++ b/.github/workflows/dotnet-npm-test.yml
@@ -206,7 +206,7 @@ jobs:
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -197,7 +197,7 @@ jobs:
         run: jf config show
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 

--- a/.github/workflows/dotnet-pack.yml
+++ b/.github/workflows/dotnet-pack.yml
@@ -106,7 +106,7 @@ jobs:
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -226,7 +226,7 @@ jobs:
         run: jf config show
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -156,7 +156,7 @@ jobs:
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -288,7 +288,7 @@ jobs:
         run: jf config show
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -187,7 +187,7 @@ jobs:
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         if: inputs.run_tests == true
         with:
           dotnet-version: ${{ inputs.dotnet_version }}

--- a/.github/workflows/jfrog-publish-aggregate-build-info.yml
+++ b/.github/workflows/jfrog-publish-aggregate-build-info.yml
@@ -143,7 +143,7 @@ jobs:
         run: jf config show
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json


### PR DESCRIPTION
v3 used Node16, v4 uses Node20

Nothing notable on the releases page for v4
https://github.com/actions/setup-dotnet/releases/tag/v4.0.0