### PR TITLE
Upgrade to actions/cache@v4 (Node v20)

### DIFF
--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -189,7 +189,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet_version }}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -99,7 +99,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |

--- a/.github/workflows/dotnet-frogbot-private-repo-scan.yml
+++ b/.github/workflows/dotnet-frogbot-private-repo-scan.yml
@@ -120,7 +120,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet_version }}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |

--- a/.github/workflows/dotnet-npm-astro-build-test-publish.yml
+++ b/.github/workflows/dotnet-npm-astro-build-test-publish.yml
@@ -275,7 +275,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
           path: |

--- a/.github/workflows/dotnet-npm-build.yml
+++ b/.github/workflows/dotnet-npm-build.yml
@@ -143,7 +143,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |

--- a/.github/workflows/dotnet-npm-test.yml
+++ b/.github/workflows/dotnet-npm-test.yml
@@ -214,7 +214,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -202,7 +202,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet_version }}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |

--- a/.github/workflows/dotnet-pack.yml
+++ b/.github/workflows/dotnet-pack.yml
@@ -111,7 +111,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet_version }}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -234,7 +234,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -164,7 +164,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -293,7 +293,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet_version }}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: inputs.run_tests == true
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -196,7 +196,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: inputs.run_tests == true
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}

--- a/.github/workflows/jfrog-publish-aggregate-build-info.yml
+++ b/.github/workflows/jfrog-publish-aggregate-build-info.yml
@@ -151,7 +151,7 @@ jobs:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |

--- a/.github/workflows/jfrog-xray-audit.yml
+++ b/.github/workflows/jfrog-xray-audit.yml
@@ -105,7 +105,7 @@ jobs:
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}
 
       - name: Setup ~/.nuget/packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: nuget-packages-${{ runner.os }}-${{ hashFiles(env.NUGETHASHFILES) }}
           path: |


### PR DESCRIPTION
v3 used Node16, v4 uses Node20

Nothing of note in the v4 release
https://github.com/actions/cache/releases/tag/v4.0.0