### PR TITLE
Upgrade to upload|download-artifact v4 (possible breakage)

### DIFF
--- a/.github/workflows/deploy-zip-to-azure-webapps.yml
+++ b/.github/workflows/deploy-zip-to-azure-webapps.yml
@@ -43,7 +43,7 @@ jobs:
           guid: ${{ env.AZUREDEPLOYSUBSCRIPTIONID }}
 
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/dotnet-jfrog-xray-scan.yml
+++ b/.github/workflows/dotnet-jfrog-xray-scan.yml
@@ -78,7 +78,7 @@ jobs:
           file_name: ${{ env.REPORTARTIFACTNAME }}
 
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload Artifacts
         id: upload-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.REPORTARTIFACTNAME }}
           path: ${{ env.REPORTARTIFACTNAME }}.json

--- a/.github/workflows/dotnet-npm-astro-build-test-publish.yml
+++ b/.github/workflows/dotnet-npm-astro-build-test-publish.yml
@@ -326,7 +326,7 @@ jobs:
 
       - name: Upload Artifacts
         id: upload-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.test_results_artifact_name }}
           path: "${{ inputs.project_directory }}**/*.trx"
@@ -401,7 +401,7 @@ jobs:
 
       - name: Upload Artifact for Deployment
         id: upload-publish-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.publish_artifact_name }}
           path: "${{ inputs.publish_working_directory }}output/${{ env.ZIPFILENAME }}"

--- a/.github/workflows/dotnet-npm-test.yml
+++ b/.github/workflows/dotnet-npm-test.yml
@@ -252,7 +252,7 @@ jobs:
 
       - name: Upload Artifacts
         id: upload-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
           path: "${{ inputs.project_directory }}**/*.trx"

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Upload Artifacts
         id: upload-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ env.ARTIFACTPATHSPEC }}

--- a/.github/workflows/dotnet-pack.yml
+++ b/.github/workflows/dotnet-pack.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload Artifacts
         id: upload-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
           path: "${{ inputs.project_directory }}artifacts/*.*nupkg"

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -322,7 +322,7 @@ jobs:
 
       - name: Upload Artifact for Deployment
         id: upload-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
           path: "${{ inputs.publish_working_directory }}output/${{ env.ZIPFILENAME }}"

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Upload Artifact for Deployment
         id: upload-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
           path: "${{ inputs.publish_working_directory }}output/${{ env.ZIPFILENAME }}"

--- a/.github/workflows/dotnet-push-github.yml
+++ b/.github/workflows/dotnet-push-github.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Download Artifacts
         id: download-artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/dotnet-push-jfrog-artifactory.yml
+++ b/.github/workflows/dotnet-push-jfrog-artifactory.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Download Artifacts
         id: download-artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/dotnet-push-myget.yml
+++ b/.github/workflows/dotnet-push-myget.yml
@@ -58,7 +58,7 @@ jobs:
   
       - name: Download Artifacts
         id: download-artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -333,7 +333,7 @@ jobs:
 
       - name: Upload Artifacts
         id: upload-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: inputs.run_tests == true
         with:
           name: ${{ inputs.artifact_name }}

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload Artifacts
         id: upload-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: inputs.run_tests == true
         with:
           name: ${{ inputs.artifact_name }}

--- a/.github/workflows/jfrog-xray-audit.yml
+++ b/.github/workflows/jfrog-xray-audit.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload Artifacts
         if: steps.audit.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.REPORTARTIFACTNAME }}
           path: ${{ env.REPORTARTIFACTNAME }}.*

--- a/.github/workflows/npm-build-test-publish.yml
+++ b/.github/workflows/npm-build-test-publish.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Upload Artifact for Deployment
         id: upload-publish-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.publish_artifact_name }}
           path: "${{ inputs.publish_working_directory }}output/${{ env.ZIPFILENAME }}"

--- a/.github/workflows/npm-pack.yml
+++ b/.github/workflows/npm-pack.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload Artifact
         id: upload-artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-outputs.outputs.artifact_name }}
           path: ${{ steps.set-outputs.outputs.artifact_file_path }}

--- a/.github/workflows/npm-publish-to-github-packages.yml
+++ b/.github/workflows/npm-publish-to-github-packages.yml
@@ -47,7 +47,7 @@ jobs:
           file_name: ${{ env.ARTIFACTFILEPATH }}          
 
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/npm-publish-to-myget.yml
+++ b/.github/workflows/npm-publish-to-myget.yml
@@ -52,7 +52,7 @@ jobs:
           file_name: ${{ env.ARTIFACTFILEPATH }} 
 
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/npm-publish-to-npmjs-org.yml
+++ b/.github/workflows/npm-publish-to-npmjs-org.yml
@@ -58,7 +58,7 @@ jobs:
           file_name: ${{ env.ARTIFACTFILEPATH }} 
 
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/actions/attach-artifact-to-release/action.yml
+++ b/actions/attach-artifact-to-release/action.yml
@@ -74,7 +74,7 @@ runs:
     # with artifacts being fairly small, we should be okay to just download
     # all of the files.
     - name: Download artifacts from build job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact_name }}
 


### PR DESCRIPTION
As noted back in 4d7c739f there are some big changes in v4 versus v3 beyond just the Node16 to Node20 upgrade.

Note that under v3, you could upload multiple files to the same artifact name.  With v4, that is no longer possible.

**This has the potential to break workflows** and will be the start of the v1.16 versions.

- https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
- https://github.com/actions/download-artifact/releases/tag/v4.0.0
- https://github.com/actions/upload-artifact/releases/tag/v4.0.0