### PR TITLE
Upgrade the build for the regex-validator to v1.15.5

### DIFF
--- a/.github/workflows/__pr-build-actions-regex-validator.yml
+++ b/.github/workflows/__pr-build-actions-regex-validator.yml
@@ -15,7 +15,7 @@ on:
 jobs:
 
   pr-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-build-test-public.yml@v1.9.2
+    uses: ritterim/public-github-actions/.github/workflows/npm-build-test-public.yml@v1.15.5
     with:
       project_directory: actions/regex-validator/
       run_tests: true


### PR DESCRIPTION
This will help reduce the Node16 deprecation warnings.