### PR TITLE
C# Package Builds Upgrade to v1.16.2, or v1.12.0

### DIFF
--- a/.github/workflows/dotnet-packages-pr-build-jfrog.yml
+++ b/.github/workflows/dotnet-packages-pr-build-jfrog.yml
@@ -83,7 +83,7 @@ on:
 jobs:
 
   version:
-    uses: ritterim/public-github-actions/.github/workflows/calculate-version-from-txt-using-github-run-id.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/calculate-version-from-txt-using-github-run-id.yml@v1.16.2
     #uses: ./.github/workflows/calculate-version-from-txt-using-github-run-id.yml
     with:
       github_run_id_baseline: ${{ inputs.github_run_id_baseline }}
@@ -91,7 +91,7 @@ jobs:
 
   dotnet-build:
     needs: [ version ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-build-jfrog.yml
     with:
       dotnet_restore_verbosity: ${{ inputs.dotnet_restore_verbosity }}
@@ -106,7 +106,7 @@ jobs:
 
   dotnet-test:
     needs: [ dotnet-build, version ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-test-jfrog.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-test-jfrog.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-test-jfrog.yml
     with:
       artifact_name: ${{ github.event.repository.name }}-testResults-${{ needs.version.outputs.informational_version }}
@@ -128,7 +128,7 @@ jobs:
       dotnet-test,
       version
       ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-pack-jfrog.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-pack-jfrog.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-pack-jfrog.yml
     with:
       artifact_name: ${{ github.event.repository.name }}-packages-${{ needs.version.outputs.informational_version }}
@@ -147,7 +147,7 @@ jobs:
 
   jfrog-publish-aggregate-build-info:
     needs: [ dotnet-build, dotnet-test, dotnet-pack, version ]
-    uses: ritterim/public-github-actions/.github/workflows/jfrog-publish-aggregate-build-info.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/jfrog-publish-aggregate-build-info.yml@v1.16.2
     #uses: ./.github/workflows/jfrog-publish-aggregate-build-info.yml
     with:
       jfrog_api_base_url: ${{ inputs.jfrog_api_base_url }}

--- a/.github/workflows/dotnet-packages-pr-build.yml
+++ b/.github/workflows/dotnet-packages-pr-build.yml
@@ -69,14 +69,14 @@ on:
 jobs:
 
   version:
-    uses: ritterim/public-github-actions/.github/workflows/calculate-version-from-txt-using-github-run-id.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/calculate-version-from-txt-using-github-run-id.yml@v1.16.2
     #uses: ./.github/workflows/calculate-version-from-txt-using-github-run-id.yml
     with:
       github_run_id_baseline: ${{ inputs.github_run_id_baseline }}
-      version_suffix: "-pr${{ github.event.number }}"
+      version_suffix: "-pr${{ github.event.number }}.${{ github.run_number }}.${{ github.run_attempt }}"
 
   build:
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.12.0
     #uses: ./.github/workflows/dotnet-build-jfrog.yml
     secrets:
       jfrog_api_key: ${{ secrets.jfrog_api_key }}
@@ -89,7 +89,7 @@ jobs:
 
   dotnet-test:
     needs: [ build, version ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-test-jfrog.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-test-jfrog.yml@v1.12.0
     #uses: ./.github/workflows/dotnet-test-jfrog.yml
     secrets:
       jfrog_api_key: ${{ secrets.jfrog_api_key }}
@@ -107,7 +107,7 @@ jobs:
 
   jfrog-xray-audit:
     needs: [ build, version ]
-    uses: ritterim/public-github-actions/.github/workflows/jfrog-xray-audit.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/jfrog-xray-audit.yml@v1.12.0
     #uses: ./.github/workflows/jfrog-xray-audit.yml
     secrets:
       jfrog_api_key: ${{ secrets.jfrog_api_key }}
@@ -119,7 +119,7 @@ jobs:
 
   dotnet-pack:
     needs: [ build, dotnet-test, jfrog-xray-audit, version ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-pack.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-pack.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-pack.yml
     with:
       artifact_name: ${{ github.event.repository.name }}-packages-${{ needs.version.outputs.informational_version }}

--- a/.github/workflows/dotnet-packages-release-build-jfrog.yml
+++ b/.github/workflows/dotnet-packages-release-build-jfrog.yml
@@ -83,14 +83,14 @@ on:
 jobs:
 
   version:
-    uses: ritterim/public-github-actions/.github/workflows/calculate-version-from-txt-using-github-run-id.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/calculate-version-from-txt-using-github-run-id.yml@v1.16.2
     #uses: ./.github/workflows/calculate-version-from-txt-using-github-run-id.yml
     with:
       github_run_id_baseline: ${{ inputs.github_run_id_baseline }}
 
   dotnet-build:
     needs: [ version ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-build-jfrog.yml
     with:
       dotnet_restore_verbosity: ${{ inputs.dotnet_restore_verbosity }}
@@ -105,7 +105,7 @@ jobs:
 
   dotnet-test:
     needs: [ dotnet-build, version ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-test-jfrog.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-test-jfrog.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-test-jfrog.yml
     with:
       artifact_name: ${{ github.event.repository.name }}-testResults-${{ needs.version.outputs.informational_version }}
@@ -127,7 +127,7 @@ jobs:
       dotnet-test,
       version
       ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-pack-jfrog.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-pack-jfrog.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-pack-jfrog.yml
     with:
       artifact_name: ${{ github.event.repository.name }}-packages-${{ needs.version.outputs.informational_version }}
@@ -146,14 +146,14 @@ jobs:
 
   dotnet-push-github:
     needs: [ dotnet-pack ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-push-github.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-push-github.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-push-github.yml
     with:
       artifact_name: ${{ needs.dotnet-pack.outputs.artifact_name }}
 
   jfrog-publish-aggregate-build-info:
     needs: [ dotnet-build, dotnet-test, dotnet-pack, version ]
-    uses: ritterim/public-github-actions/.github/workflows/jfrog-publish-aggregate-build-info.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/jfrog-publish-aggregate-build-info.yml@v1.16.2
     #uses: ./.github/workflows/jfrog-publish-aggregate-build-info.yml
     with:
       jfrog_api_base_url: ${{ inputs.jfrog_api_base_url }}

--- a/.github/workflows/dotnet-private-packages-release-build.yml
+++ b/.github/workflows/dotnet-private-packages-release-build.yml
@@ -89,7 +89,7 @@ jobs:
       github_run_id_baseline: ${{ inputs.github_run_id_baseline }}
 
   build:
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-build-jfrog.yml@v1.12.0
     #uses: ./.github/workflows/dotnet-build-jfrog.yml
     secrets:
       jfrog_api_key: ${{ secrets.jfrog_api_key }}
@@ -102,7 +102,7 @@ jobs:
 
   dotnet-test:
     needs: [ build, version ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-test-jfrog.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-test-jfrog.yml@v1.12.0
     #uses: ./.github/workflows/dotnet-test-jfrog.yml
     secrets:
       jfrog_api_key: ${{ secrets.jfrog_api_key }}
@@ -120,7 +120,7 @@ jobs:
 
   jfrog-xray-audit:
     needs: [ build, version ]
-    uses: ritterim/public-github-actions/.github/workflows/jfrog-xray-audit.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/jfrog-xray-audit.yml@v1.12.0
     #uses: ./.github/workflows/jfrog-xray-audit.yml
     secrets:
       jfrog_api_key: ${{ secrets.jfrog_api_key }}
@@ -132,7 +132,7 @@ jobs:
 
   dotnet-pack:
     needs: [ build, dotnet-test, jfrog-xray-audit, version ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-pack.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-pack.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-pack.yml
     with:
       artifact_name: ${{ github.event.repository.name }}-packages-${{ needs.version.outputs.informational_version }}
@@ -145,14 +145,14 @@ jobs:
 
   dotnet-push-github:
     needs: [ dotnet-pack ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-push-github.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-push-github.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-push-github.yml
     with:
       artifact_name: ${{ needs.dotnet-pack.outputs.artifact_name }}
 
   dotnet-push-jfrog-artifactory:
     needs: [ build, dotnet-pack ]
-    uses: ritterim/public-github-actions/.github/workflows/dotnet-push-jfrog-artifactory.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/dotnet-push-jfrog-artifactory.yml@v1.16.2
     #uses: ./.github/workflows/dotnet-push-jfrog-artifactory.yml
     secrets:
       jfrog_api_key: ${{ secrets.jfrog_publish_api_key }}


### PR DESCRIPTION
For cases where we broke things, downgrade to v1.12.0 (what was there before).

Otherwise, upgrade to v1.16.2