### PR TITLE
Add github_job_runner_spec input to Astro build

### DIFF
--- a/.github/workflows/dotnet-npm-astro-build-test-publish.yml
+++ b/.github/workflows/dotnet-npm-astro-build-test-publish.yml
@@ -47,6 +47,11 @@ on:
         type: string
         default: "release"
 
+      github_job_runner_spec:
+        description: Which GitHub Runner to use.  Default is 'ubuntu-latest'.
+        type: string
+        default: "ubuntu-latest"
+
       publish_artifact_name:
         required: true
         type: string
@@ -137,7 +142,7 @@ jobs:
 
   build-test-publish:
     name: Build-Test-Publish (.NET/NPM)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.github_job_runner_spec }}
     defaults:
       run:
         working-directory: ${{ inputs.project_directory }}


### PR DESCRIPTION
Still default to ubuntu-latest, but allow the caller to pick a larger runner if needed.