### PR TITLE
Add git_commit_date/timestamp to NPM version calcs

### DIFF
--- a/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
+++ b/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
@@ -76,6 +76,14 @@ on:
         description: The UTC build date/time in ISO-8601 format.  Includes hours/minutes/seconds.
         value: ${{ jobs.version.outputs.build_timestamp }}
 
+      git_commit_date:
+        description: The UTC date of the git commit in ISO-8601 format.
+        value: ${{ jobs.version.outputs.git_commit_date }}
+
+      git_commit_timestamp:
+        description: The UTC date/time of the git commit in ISO-8601 format.  Includes hours/minutes/seconds.
+        value: ${{ jobs.version.outputs.git_commit_timestamp }}
+
 env:
   version_number_pattern: '[0-9]{1,5}\.[0-9]{1,5}\.[0-9]{1,5}'
   major_minor_version_number_pattern: '^[0-9]{1,5}\.[0-9]{1,5}'
@@ -113,6 +121,8 @@ jobs:
       version_incremented: ${{ steps.set-outputs.outputs.version_incremented }}
       build_date: ${{ steps.set-outputs.outputs.build_date }}
       build_timestamp: ${{ steps.set-outputs.outputs.build_timestamp }}
+      git_commit_date: ${{ steps.set-outputs.outputs.git_commit_date }}
+      git_commit_timestamp: ${{ steps.set-outputs.outputs.git_commit_timestamp }}
 
     steps:
 
@@ -242,6 +252,15 @@ jobs:
           echo "BUILDTIMESTAMP=$BUILDTIMESTAMP"
           echo "BUILDTIMESTAMP=$BUILDTIMESTAMP" >> $GITHUB_ENV
 
+      - name: Calculate git commit date/timestamp
+        run: |
+          GITCOMMITDATE=$(TZ=UTC0 git show --no-patch --no-notes --pretty='%cs' $GH_SHA_CALC)
+          echo "GITCOMMITDATE=$GITCOMMITDATE"
+          echo "GITCOMMITDATE=$GITCOMMITDATE" >> $GITHUB_ENV
+          GITCOMMITTIMESTAMP=$(TZ=UTC0 git show --no-patch --no-notes --pretty='%cI' $GH_SHA_CALC)
+          echo "GITCOMMITTIMESTAMP=$GITCOMMITTIMESTAMP"
+          echo "GITCOMMITTIMESTAMP=$GITCOMMITTIMESTAMP" >> $GITHUB_ENV
+
       - name: Set outputs
         id: set-outputs
         run: |
@@ -255,6 +274,8 @@ jobs:
           echo "version_incremented=$VERSION_INCREMENTED" >> $GITHUB_OUTPUT
           echo "build_date=${BUILDDATE}" >> $GITHUB_OUTPUT
           echo "build_timestamp=${BUILDTIMESTAMP}" >> $GITHUB_OUTPUT
+          echo "git_commit_date=${GITCOMMITDATE}" >> $GITHUB_OUTPUT
+          echo "git_commit_timestamp=${GITCOMMITTIMESTAMP}" >> $GITHUB_OUTPUT
 
       - name: Echo Output Variables
         run: |
@@ -268,3 +289,5 @@ jobs:
           echo "version_incremented=${{ steps.set-outputs.outputs.version_incremented }}"
           echo "build_date=${{ steps.set-outputs.outputs.build_date }}"
           echo "build_timestamp=${{ steps.set-outputs.outputs.build_timestamp }}"
+          echo "git_commit_date=${{ steps.set-outputs.outputs.git_commit_date }}"
+          echo "git_commit_timestamp=${{ steps.set-outputs.outputs.git_commit_timestamp }}"


### PR DESCRIPTION
Output the git commit's date and timestamp when calculating the version for an NPM project that uses issue labels to increment the version.