### PR TITLE
Use HEAD for the NPM git commit date/time calcs

### DIFF
--- a/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
+++ b/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
@@ -254,10 +254,10 @@ jobs:
 
       - name: Calculate git commit date/timestamp
         run: |
-          GITCOMMITDATE=$(TZ=UTC0 git show --no-patch --no-notes --pretty='%cs' $GH_SHA_CALC)
+          GITCOMMITDATE=$(TZ=UTC0 git show --no-patch --no-notes --pretty='%cs' HEAD)
           echo "GITCOMMITDATE=$GITCOMMITDATE"
           echo "GITCOMMITDATE=$GITCOMMITDATE" >> $GITHUB_ENV
-          GITCOMMITTIMESTAMP=$(TZ=UTC0 git show --no-patch --no-notes --pretty='%cI' $GH_SHA_CALC)
+          GITCOMMITTIMESTAMP=$(TZ=UTC0 git show --no-patch --no-notes --pretty='%cI' HEAD)
           echo "GITCOMMITTIMESTAMP=$GITCOMMITTIMESTAMP"
           echo "GITCOMMITTIMESTAMP=$GITCOMMITTIMESTAMP" >> $GITHUB_ENV
 


### PR DESCRIPTION
When running on a PR build (not yet merged), the hash from PULL_REQUEST_HEAD_SHA does not yet exist in
a way that is visible to "git show".

So it's better to use "HEAD" as the ref here.

fix for #178