### PR TITLE
Allow for github.run_id > 10000000000

### DIFF
--- a/actions/calculate-version-from-txt-using-github-run-id/action.yml
+++ b/actions/calculate-version-from-txt-using-github-run-id/action.yml
@@ -94,7 +94,7 @@ runs:
         BASELINE=$(("${BASELINE}"))
         echo "GHRUNID=${GHRUNID}"
         echo "BASELINE=${BASELINE}"
-        if (( "${BASELINE}" < 5200000000 || "${BASELINE}" > 10000000000 )); then
+        if (( "${BASELINE}" < 5200000000 || "${BASELINE}" > 90000000000 )); then
           echo "The 'inputs.github_run_id_baseline' value was not within the acceptable range."
           exit 1
         fi


### PR DESCRIPTION
GitHub Run IDs have exceeded `10000000000`.