### PR TITLE
Upgrade calculate version to use latest action versions

### DIFF
--- a/.github/workflows/calculate-version-from-txt-using-github-run-id.yml
+++ b/.github/workflows/calculate-version-from-txt-using-github-run-id.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Calculate Version
         id: version
-        uses: ritterim/public-github-actions/actions/calculate-version-from-txt-using-github-run-id@v1.16.5
+        uses: ritterim/public-github-actions/actions/calculate-version-from-txt-using-github-run-id@v1.17.1
         with:
           version_suffix: ${{ inputs.version_suffix }}
           github_run_id_baseline: ${{ inputs.github_run_id_baseline }}

--- a/actions/calculate-version-from-txt-using-github-run-id/README.md
+++ b/actions/calculate-version-from-txt-using-github-run-id/README.md
@@ -42,7 +42,7 @@ Note that you *must* have a `version.txt` file in the root of the repository wit
 
       - name: Calculate Version
         id: version
-        uses: ritterim/public-github-actions/actions/calculate-version-from-txt-using-github-run-id@v1.16.0
+        uses: ritterim/public-github-actions/actions/calculate-version-from-txt-using-github-run-id@v1.17.1
         with:
           version_suffix: "-alpha${{ github.run_number }}"
           github_run_id_baseline: 6100000000


### PR DESCRIPTION
Pulls in 96a3cfc6 which allows for larger github.run_id values.