### PR TITLE
Add npm-build-test-publish-v2.yml reusable workflow

### DIFF
--- a/.github/workflows/npm-build-test-publish-v2.yml
+++ b/.github/workflows/npm-build-test-publish-v2.yml
@@ -1,0 +1,435 @@
+name: Build-Test-Publish (NPM)
+
+# This build-test workflow will NOT persist the workspace.
+# We use this on larger site builds where the artifact is over a few hundred megabytes.
+# But it can also be used in situations where you don't want separate build/test/publish jobs.
+
+# To integrate with the NPM 'ci:build', we are going to define the following
+# environment variables:
+# - TARGET_BRAND (standard, whitelabel)
+# - TARGET_ENVIRONMENT (development, staging, production, etc.)
+# - TARGET_CONFIGURATION (release, debug)
+# Note that these should be treated as case-sensitive.
+
+# This requires JFrog Artifactory integration.
+
+permissions:
+  contents: read
+  id-token: write
+
+on:
+
+  workflow_call:
+
+    inputs:
+
+      artifact_retention_days:
+        required: false
+        type: number
+        default: 30
+
+      jfrog_api_base_url:
+        description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
+        required: true
+        type: string
+
+      jfrog_build_name:
+        description: 'JFrog build name.'
+        required: true
+        type: string
+
+      jfrog_build_number:
+        description: 'JFrog build number. Can be an integer, a semantic version, or a string.'
+        required: true
+        type: string
+
+      jfrog_cli_log_level:
+        description: 'Set the log level for the JFrog CLI. Default is ERROR. Values are: (DEBUG, INFO, WARN, ERROR).'
+        required: false
+        default: ERROR
+        type: string
+
+      jfrog_npm_feed_repo:
+        description: The 'virtual' JFrog Artifactory repository identifier for NPM package retrieval.
+        required: true
+        type: string
+
+      jfrog_oidc_provider_name:
+        description: The OIDC Integration Provider Name to use for authentication from the GitHub Action to the JFrog instance.
+        required: true
+        type: string
+
+      publish_artifact_name:
+        required: true
+        type: string
+
+      node_version:
+        description: The node version to install such as '18.x'.  It is best to stick to LTS releases of nodejs to avoid slow build times.
+        required: false
+        type: string
+        default: '20.x'
+
+      npm_package_json_filename:
+        description: Name of the 'package.json' file if not the default name.
+        required: false
+        type: string
+        default: package.json
+
+      npm_package_lock_json_filename:
+        description: Name of the 'package-lock.json' file if not the default name.
+        required: false
+        type: string
+        default: package-lock.json
+
+      npm_project_directory:
+        description: Location of the package.json file for the NPM package.
+        required: false
+        type: string
+        default: ./
+
+      publish_artifact_directory:
+        required: false
+        type: string
+        default: dist/
+
+      publish_working_directory:
+        required: false
+        type: string
+        default: ./
+
+      target_brand:
+        description: Pass in 'standard' or 'whitelabel'.
+        default: standard
+        required: false
+        type: string
+
+      target_environment:
+        description: Pass in development, staging, production, etc.
+        required: true
+        type: string
+
+      target_configuration:
+        description: Pass in 'release', 'debug'.  Controls whether to minify javascript and other debug vs release optimizations.
+        required: false
+        type: string
+        default: "release"
+        
+      informational_version:
+        required: true
+        type: string
+
+      version:
+        required: true
+        type: string
+
+    outputs:
+
+      node_version:
+        value: ${{ inputs.node_version }}
+
+      npm_package_json_filename:
+        value: ${{ inputs.npm_package_json_filename }}
+
+      npm_package_lock_json_filename:
+        value: ${{ inputs.npm_package_json_filename }}
+
+      npm_project_directory:
+        value: ${{ inputs.npm_project_directory }}
+
+      publish_artifact_name:
+        value: ${{ jobs.build-test-publish.outputs.publish_artifact_name }}
+
+      publish_artifact_filename:
+        value: ${{ jobs.build-test-publish.outputs.publish_artifact_filename }}
+
+jobs:
+
+  build-test-publish:
+    name: Build-Test-Publish (NPM)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.npm_project_directory }}
+
+    env:
+      PUBLISHARTIFACTDIRECTORY: ${{ inputs.publish_artifact_directory }}
+      PUBLISHWORKINGDIRECTORY: ${{ inputs.publish_working_directory }}
+      PUBLISHARTIFACTNAME: ${{ inputs.publish_artifact_name }}
+      NPMPACKAGEJSONFILENAME: ${{ inputs.npm_package_json_filename }}
+      NPMPACKAGELOCKJSONFILENAME: ${{ inputs.npm_package_lock_json_filename }}
+      NPMPROJECTDIRECTORY: ${{ inputs.npm_project_directory }}
+      INFORMATIONALVERSION: ${{ inputs.informational_version }}
+      JFROG_API_BASE_URL: ${{ inputs.jfrog_api_base_url }}
+      JFROG_CLI_BUILD_NAME: "${{ inputs.jfrog_build_name }}-dotnet-build"
+      JFROG_CLI_BUILD_NUMBER: ${{ inputs.jfrog_build_number }}
+      JFROG_CLI_LOG_LEVEL: ${{ inputs.jfrog_cli_log_level }}
+      JFROG_NPM_FEED_REPO: ${{ inputs.jfrog_npm_feed_repo }}
+      JFROG_OIDC_PROVIDER_NAME: ${{ inputs.jfrog_oidc_provider_name }}
+      JFROG_SETUP_DEFAULT_SERVER_ID: setup-jfrog-cli-server
+      VERSION: ${{ inputs.version }}
+      ZIPFILENAME: "${{ inputs.publish_artifact_name }}.zip"
+      TARGET_BRAND: ${{ inputs.target_brand }}
+      TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+      TARGET_CONFIGURATION: ${{ inputs.target_configuration }}
+
+    outputs:
+      publish_artifact_name: ${{ inputs.publish_artifact_name }}
+      publish_artifact_filename: ${{ env.ZIPFILENAME }}
+
+    steps:
+
+      - name: Validate inputs.publish_artifact_name
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17.2
+        with:
+          file_name: ${{ env.PUBLISHARTIFACTNAME }}
+
+      - name: Validate inputs.npm_package_json_filename
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17.2
+        with:
+          file_name: ${{ env.NPMPACKAGEJSONFILENAME }}
+
+      - name: Validate inputs.npm_package_lock_json_filename
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17.2
+        with:
+          file_name: ${{ env.NPMPACKAGELOCKJSONFILENAME }}
+
+      - name: Validate inputs.npm_project_directory
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17.2
+        with:
+          path_name: ${{ env.NPMPROJECTDIRECTORY }}
+
+      - name: Validate inputs.publish_artifact_directory
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17.2
+        with:
+          path_name: ${{ env.PUBLISHARTIFACTDIRECTORY }}
+
+      - name: Validate inputs.publish_working_directory
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17.2
+        with:
+          path_name: ${{ env.PUBLISHWORKINGDIRECTORY }}
+
+      - name: Validate inputs.informational_version
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17.2
+        with:
+          version: ${{ env.INFORMATIONALVERSION }}
+
+      - name: Validate inputs.jfrog_build_name
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        with: # This regex pattern is a bit of a guess
+          regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
+          value: ${{ inputs.jfrog_build_name }}
+
+      - name: Validate inputs.jfrog_npm_feed_repo
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        with:
+          name: ${{ env.JFROG_NPM_FEED_REPO }}
+
+      - name: Validate inputs.jfrog_oidc_provider_name
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        with: # This regex pattern is a bit of a guess
+          regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
+          value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
+
+      - name: Validate inputs.version
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17.2
+        with:
+          version: ${{ env.VERSION }}
+
+      - name: Validate ZIPFILENAME
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17.2
+        with:
+          file_name: ${{ env.ZIPFILENAME }}
+
+      - name: Validate inputs.target_brand
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17.2
+        with:
+          value: ${{ env.TARGET_BRAND }}
+          regex_pattern: '^(standard|whitelabel)$'
+
+      - name: Validate inputs.target_environment
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17.2
+        with:
+          value: ${{ env.TARGET_ENVIRONMENT }}
+          regex_pattern: '^(development|staging|production)$'
+
+      - name: Validate inputs.target_configuration
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17.2
+        with:
+          value: ${{ env.TARGET_CONFIGURATION }}
+          regex_pattern: '^(release|debug)$'
+
+      - name: github context debug information
+        working-directory: ./
+        run: |
+          echo "github.base_ref=${{ github.base_ref }}"
+          echo "github.head_ref=${{ github.head_ref }}"
+          echo "github.ref=${{ github.ref }}"
+          echo "github.ref_name=${{ github.ref_name }}"
+          echo "github.repository=${{ github.repository }}"
+          echo "github.repository_owner=${{ github.repository_owner }}"
+          echo "github.run_id=${{ github.run_id }}"
+          echo "github.run_number=${{ github.run_number }}"
+          echo "github.run_attempt=${{ github.run_attempt }}"
+          echo "github.sha=${{ github.sha }}"
+
+      - name: Checkout Project
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          lfs: true
+
+      # This creates the setup-jfrog-cli-server server ID
+      - name: Install JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: ${{ env.JFROG_API_BASE_URL }}
+        with:
+          oidc-provider-name: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
+
+      - name: jf config show JFROG_SETUP_DEFAULT_SERVER_ID
+        run: jf config show "$JFROG_SETUP_DEFAULT_SERVER_ID"
+
+      - run: ls -la "$NPMPACKAGEJSONFILENAME"
+
+      - run: ls -la "$NPMPACKAGELOCKJSONFILENAME"
+
+      # See this for why setup-node can be slow: https://github.com/actions/setup-node/issues/726#issuecomment-1527198808
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: 'npm'
+          cache-dependency-path: "${{ inputs.npm_project_directory }}${{ inputs.npm_package_lock_json_filename }}"
+
+      - name: Check NPM configuration
+        run: npm config list -l
+
+      - name: Configure NPM using JFrog CLI
+        run: |
+          jf npm-config --global --server-id-resolve setup-jfrog-cli-server --repo-resolve "${JFROG_NPM_FEED_REPO}"
+          JFTOKEN=$(jf access-token-create --description="$0" | jq --raw-output '.access_token')
+          echo "::add-mask::${JFTOKEN}"
+          echo "JFTOKEN=${JFTOKEN}"
+          npm config set registry="${JFROG_API_BASE_URL}artifactory/api/npm/${JFROG_NPM_FEED_REPO}/"
+          npm config set "//rimdev.jfrog.io/artifactory/api/npm/${JFROG_NPM_FEED_REPO}/:_authToken=${JFTOKEN}"
+
+      - name: Check NPM configuration
+        run: npm config list -l
+
+      # https://jfrog.com/help/r/artifactory-how-to-troubleshoot-long-npm-install-times-with-s3-redirect-enabled/artifactory-how-to-troubleshoot-long-npm-install-times-with-s3-redirect-enabled
+      # > sometimes the npm install process will appear to hang for several minutes, causing long build times for npm projects
+      # > Any npm configuration flag that disables the progress bar will alleviate this issue
+      - name: jf npm ci
+        working-directory:  ${{ env.NPMPROJECTDIRECTORY }}
+        run: |
+          jf npm ci --npm-args="--no-progress"
+
+      - name: Check version in ${{ inputs.npm_package_json_filename }}
+        run: jq -r '.version' "${NPMPACKAGEJSONFILENAME}"
+
+      - name: npm version config
+        run: |
+          npm config set allow-same-version=true
+          npm config set git-tag-version=false
+          npm config set sign-git-tag=false
+
+      # Note the use of '--ignore-scripts' here to prevent 'npm version' from running any scripts in the package.json
+      - run: npm version --ignore-scripts "${VERSION}"
+
+      - name: Check version in ${{ inputs.npm_package_json_filename }}
+        run: jq -r '.version' "${NPMPACKAGEJSONFILENAME}"
+
+      - name: jf npm run ci:build
+        working-directory:  ${{ env.NPMPROJECTDIRECTORY }}
+        run: jf npm run ci:build --verbose
+
+      - run: ls -la
+
+      - name: npm run test
+        working-directory:  ${{ env.NPMPROJECTDIRECTORY }}
+        run: npm run test
+
+      - name: mkdir -p "${{ env.PUBLISHARTIFACTDIRECTORY }}"
+        working-directory: ${{ inputs.publish_working_directory }}
+        run: mkdir -p "${PUBLISHARTIFACTDIRECTORY}"
+
+      - name: Environment based robots.txt /disallow  
+        working-directory:  ${{ inputs.publish_working_directory }}
+        if: env.TARGET_ENVIRONMENT == 'development'
+        run: |
+          cat > "${PUBLISHARTIFACTDIRECTORY}robots.txt" <<EOF
+          User-agent: *
+          Disallow: /
+          EOF
+
+      - name: Create _git_hash/index.html file
+        working-directory: ${{ inputs.publish_working_directory }}
+        run: |
+          PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          GH_SHA="${PULL_REQUEST_HEAD_SHA:-${GITHUB_SHA:-ERROR}}"
+          mkdir -p "${PUBLISHARTIFACTDIRECTORY}_git_hash"
+          echo $GH_SHA > "${PUBLISHARTIFACTDIRECTORY}_git_hash/index.html"
+          cat "${PUBLISHARTIFACTDIRECTORY}_git_hash/index.html"
+
+      - name: Create _version/index.html file
+        working-directory: ${{ inputs.publish_working_directory }}
+        run: |
+          BUILDDATE=$(date -u -Idate)
+          echo "BUILDDATE=$BUILDDATE"
+          BUILDTIMESTAMP=$(date -u -Iseconds)
+          echo "BUILDTIMESTAMP=$BUILDTIMESTAMP"
+          PULL_REQUEST_HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          GH_SHA="${PULL_REQUEST_HEAD_SHA:-${GITHUB_SHA:-ERROR}}"
+          echo "GH_SHA=$GH_SHA"
+          BODY=$(jq --null-input \
+            --arg buildDate "$BUILDDATE" \
+            --arg buildTimestamp "$BUILDTIMESTAMP" \
+            --arg gitHash "$GH_SHA" \
+            --arg informationalVersion "$INFORMATIONALVERSION" \
+            --arg version "$VERSION" \
+            '{"buildDate": $buildDate, "buildTimestamp": $buildTimestamp, "gitHash": $gitHash, "informationalVersion": $informationalVersion, "version": $version}' \
+            )
+          mkdir -p "${PUBLISHARTIFACTDIRECTORY}_version"
+          echo "$BODY" > "${PUBLISHARTIFACTDIRECTORY}_version/index.html"
+          cat "${PUBLISHARTIFACTDIRECTORY}_version/index.html"
+
+      - name: ls -l "${{ env.PUBLISHARTIFACTDIRECTORY }}"
+        working-directory: ${{ inputs.publish_working_directory }}
+        run: ls -l "${PUBLISHARTIFACTDIRECTORY}"
+
+      - name: Create output directory.
+        working-directory: ${{ inputs.publish_working_directory }}
+        run: mkdir -p 'output'
+
+      - name: Create Release Zip File
+        working-directory: "${{ inputs.publish_working_directory }}${{ inputs.publish_artifact_directory }}"
+        run: |
+          zip -v -r \
+            "../output/${ZIPFILENAME}" \
+            .
+
+      - name: Inspect output directory.
+        working-directory: ${{ inputs.publish_working_directory }}
+        run: ls -lt output/*.zip
+
+      - name: Test Release Zip File
+        working-directory: ${{ inputs.publish_working_directory }}
+        run: zip -T "output/${ZIPFILENAME}"
+
+      - name: Upload Artifact for Deployment
+        id: upload-publish-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.publish_artifact_name }}
+          path: "${{ inputs.publish_working_directory }}output/${{ env.ZIPFILENAME }}"
+          retention-days: ${{ inputs.artifact_retention_days }}
+          if-no-files-found: error
+
+      - name: Collect JFrog Build Information
+        run: jf rt build-collect-env "${JFROG_CLI_BUILD_NAME}" "${JFROG_CLI_BUILD_NUMBER}"
+
+      - name: Collect JFrog 'git' Information
+        run: jf rt build-add-git "${JFROG_CLI_BUILD_NAME}" "${JFROG_CLI_BUILD_NUMBER}"
+
+      - name: Push JFrog Build Information
+        run: jf rt build-publish "${JFROG_CLI_BUILD_NAME}" "${JFROG_CLI_BUILD_NUMBER}"          


### PR DESCRIPTION
- JFrog integration via OIDC federation
- JFrog build-info integration
- Pulls NPM packages from JFrog Artifactory
- Astro build with TARGET_ENVIRONMENT env var support
- Does not persist the workspace as a GH Actions artifact
- NPM v20 default
- Node cache is based off of the package-lock.json file
- Creates a "_version/index.html" file
- Creates a "_git_hash/index.html" file
- Produces an zip file for deployment to the Azure Web App