### PR TITLE
Breaking: Remove GH Package in JFrog build-info

### DIFF
--- a/.github/workflows/jfrog-publish-aggregate-build-info.yml
+++ b/.github/workflows/jfrog-publish-aggregate-build-info.yml
@@ -8,7 +8,6 @@ name: Publish Aggregate JFrog Build-Info
 permissions:
   contents: read
   id-token: write
-  packages: read
 
 on:
 
@@ -167,9 +166,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
-          source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup ~/.nuget/packages cache
         uses: actions/cache@v4


### PR DESCRIPTION
If we're using JFrog Artifactory, we no longer need to auth to GitHub Packages.  Nor should we be reading from GitHub Packages for the NuGet feed.