### PR TITLE
Add missing dotnet_version input on JFrog build-info

### DIFF
--- a/.github/workflows/jfrog-publish-aggregate-build-info.yml
+++ b/.github/workflows/jfrog-publish-aggregate-build-info.yml
@@ -16,6 +16,11 @@ on:
 
     inputs:
 
+      dotnet_version:
+        required: false
+        type: string
+        default: "6.0"
+
       jfrog_api_base_url:
         description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
         required: true


### PR DESCRIPTION
Without this, the 'actions/setup-dotnet@v4' step might pull in a version you don't want.