### PR TITLE
Pin to v4.4.3 for jfrog/setup-jfrog-cli action

### DIFF
--- a/.github/workflows/build-dotnet-framework-jfrog.yml
+++ b/.github/workflows/build-dotnet-framework-jfrog.yml
@@ -182,7 +182,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -174,7 +174,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-npm-build-jfrog.yml
+++ b/.github/workflows/dotnet-npm-build-jfrog.yml
@@ -253,7 +253,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-npm-publish-jfrog.yml
+++ b/.github/workflows/dotnet-npm-publish-jfrog.yml
@@ -280,7 +280,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-npm-test-jfrog.yml
+++ b/.github/workflows/dotnet-npm-test-jfrog.yml
@@ -337,7 +337,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -187,7 +187,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -216,7 +216,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -278,7 +278,7 @@ jobs:
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}
 
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/jfrog-publish-aggregate-build-info.yml
+++ b/.github/workflows/jfrog-publish-aggregate-build-info.yml
@@ -158,7 +158,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/jfrog-xray-audit.yml
+++ b/.github/workflows/jfrog-xray-audit.yml
@@ -112,7 +112,7 @@ jobs:
             ~/.nuget/packages
 
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-build-jfrog.yml
+++ b/.github/workflows/npm-build-jfrog.yml
@@ -165,7 +165,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-build-test-publish-v2.yml
+++ b/.github/workflows/npm-build-test-publish-v2.yml
@@ -280,7 +280,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-pack-jfrog.yml
+++ b/.github/workflows/npm-pack-jfrog.yml
@@ -198,7 +198,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-test-jfrog.yml
+++ b/.github/workflows/npm-test-jfrog.yml
@@ -135,7 +135,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.4.3
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:


### PR DESCRIPTION
There is a breaking change in v4.5.0 of the GitHub Action jfrog/setup-jfrog-cli where the default server ID is no longer predictable.  They added a new property named 'custom-server-id', but gave no notice.

This will push out as a bug fix under v1.17.5 (or the next patch tag)

The breaking change will be saved for the v2 line of the actions.