### PR TITLE
Revert "Pin to v4.4.3 for jfrog/setup-jfrog-cli action"

### DIFF
--- a/.github/workflows/build-dotnet-framework-jfrog.yml
+++ b/.github/workflows/build-dotnet-framework-jfrog.yml
@@ -182,7 +182,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -174,7 +174,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-npm-build-jfrog.yml
+++ b/.github/workflows/dotnet-npm-build-jfrog.yml
@@ -253,7 +253,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-npm-publish-jfrog.yml
+++ b/.github/workflows/dotnet-npm-publish-jfrog.yml
@@ -280,7 +280,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-npm-test-jfrog.yml
+++ b/.github/workflows/dotnet-npm-test-jfrog.yml
@@ -337,7 +337,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -187,7 +187,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -216,7 +216,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -278,7 +278,7 @@ jobs:
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}
 
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/jfrog-publish-aggregate-build-info.yml
+++ b/.github/workflows/jfrog-publish-aggregate-build-info.yml
@@ -158,7 +158,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/jfrog-xray-audit.yml
+++ b/.github/workflows/jfrog-xray-audit.yml
@@ -112,7 +112,7 @@ jobs:
             ~/.nuget/packages
 
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-build-jfrog.yml
+++ b/.github/workflows/npm-build-jfrog.yml
@@ -165,7 +165,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-build-test-publish-v2.yml
+++ b/.github/workflows/npm-build-test-publish-v2.yml
@@ -280,7 +280,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-pack-jfrog.yml
+++ b/.github/workflows/npm-pack-jfrog.yml
@@ -198,7 +198,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-test-jfrog.yml
+++ b/.github/workflows/npm-test-jfrog.yml
@@ -135,7 +135,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4.4.3
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:


### PR DESCRIPTION
This reverts commit e9b22c1ef1814756f10d335e870363a5e8f88c2b from https://github.com/ritterim/public-github-actions/pull/217

JFrog reversed on making the existing default server ID different from what was there before in version 4.5.1.  So now workflows using the v4 of the jfrog/setup-jfrog-cli  GitHub action will no longer misbehave when they pull the latest for
the 'v4' tag.

Note that they still added the 'custom-server-id' input so that we can start customizing it for our needs and protect against future breakage. I'm not sure if they will be reintroducing the change in v5, so we might want to start specifying our own custom server ID.