### PR TITLE
Upgrade composite actions to use v1.17 floating tag

### DIFF
--- a/actions/attach-artifact-to-release/action.yml
+++ b/actions/attach-artifact-to-release/action.yml
@@ -32,31 +32,31 @@ runs:
   steps:
 
     - name: Validate inputs.artifact_name
-      uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
       env:
         ARTIFACTNAME: ${{ inputs.artifact_name }}
       with:
         file_name: ${{ env.ARTIFACTNAME }}
 
     - name: Validate inputs.artifact_file_path
-      uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
       env:
         ARTIFACTFILEPATH: ${{ inputs.artifact_file_path }}
       with:
         file_name: ${{ env.ARTIFACTFILEPATH }}
 
     - name: Validate inputs.github_repository
-      uses: ritterim/public-github-actions/actions/github-org-repository-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/github-org-repository-validator@v1.17
       with:
         github_repository: ${{ inputs.github_repository }}
 
     - name: Validate inputs.github_token
-      uses: ritterim/public-github-actions/actions/github-token-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/github-token-validator@v1.17
       with:
         token: ${{ inputs.github_token }}
 
     - name: Validate inputs.version_tag
-      uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
       env:
         VERSIONTAG: ${{ inputs.version_tag }}
       with:

--- a/actions/calculate-version-from-txt-using-github-run-id/action.yml
+++ b/actions/calculate-version-from-txt-using-github-run-id/action.yml
@@ -79,7 +79,7 @@ runs:
       shell: bash
 
     - name: Validate inputs.github_run_id_baseline
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.github_run_id_baseline }}
         regex_pattern: '^[0-9]{10,12}$'    

--- a/actions/file-name-validator/action.yml
+++ b/actions/file-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.file_name }}
         regex_pattern: '^[A-Za-z0-9_\.\+-]{3,70}$'

--- a/actions/file-path-name-validator/action.yml
+++ b/actions/file-path-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.file_path_name }}
         regex_pattern: '^[A-Za-z0-9_\.\+\/-]{2,90}$'

--- a/actions/github-org-repository-validator/action.yml
+++ b/actions/github-org-repository-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.github_repository }}
         regex_pattern: '^[a-zA-Z0-9-]{1,25}\/[a-zA-Z0-9-]{1,50}$'

--- a/actions/github-token-validator/action.yml
+++ b/actions/github-token-validator/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
 
     - name: Validate token
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.token }}
         regex_pattern: '^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$'

--- a/actions/guid-validator/action.yml
+++ b/actions/guid-validator/action.yml
@@ -26,7 +26,7 @@ runs:
     # FUTURE: Allow curly braces with a boolean input option using '^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$'
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.guid }}
         regex_pattern: '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'

--- a/actions/jfrog-artifactory-repository-name-validator/action.yml
+++ b/actions/jfrog-artifactory-repository-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.name }}
         regex_pattern: '^[A-Za-z0-9\-]{5,55}$'

--- a/actions/npm-config-github-packages-repository/action.yml
+++ b/actions/npm-config-github-packages-repository/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
 
     - name: Validate inputs.npm_scope
-      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.17
       with:
         npm_scope: ${{ inputs.npm_scope }}
 

--- a/actions/npm-config-myget-packages-repository/action.yml
+++ b/actions/npm-config-myget-packages-repository/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate inputs.npm_scope
-      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.17
       with:
         npm_scope: ${{ inputs.npm_scope }}
 

--- a/actions/npm-config-npmjs-org-registry/action.yml
+++ b/actions/npm-config-npmjs-org-registry/action.yml
@@ -24,12 +24,12 @@ runs:
   steps:
 
     - name: Validate inputs.npm_scope
-      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.17
       with:
         npm_scope: ${{ inputs.npm_scope }}
 
     - name: Validate inputs.npmjs_org_api_key
-      uses: ritterim/public-github-actions/actions/npmjs-access-token-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/npmjs-access-token-validator@v1.17
       with:
         token: ${{ inputs.npmjs_org_api_key }}
 

--- a/actions/npm-package-name-validator/action.yml
+++ b/actions/npm-package-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.package_name }}
         regex_pattern: '^[a-z0-9\-]{5,40}$'

--- a/actions/npm-package-scope-validator/action.yml
+++ b/actions/npm-package-scope-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.npm_scope }}
         regex_pattern: '^[a-z0-9\-]{5,25}$'

--- a/actions/npmjs-access-token-validator/action.yml
+++ b/actions/npmjs-access-token-validator/action.yml
@@ -25,7 +25,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.token }}
         regex_pattern: '^(npm_[A-Za-z0-9]{36})$'

--- a/actions/path-name-validator/action.yml
+++ b/actions/path-name-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.path_name }}
         regex_pattern: '^[A-Za-z0-9_\.\+\/-]{1,70}\/$'

--- a/actions/version-number-major-minor-validator/action.yml
+++ b/actions/version-number-major-minor-validator/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Validate
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.version }}
         regex_pattern: '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)?$'

--- a/actions/version-number-validator/action.yml
+++ b/actions/version-number-validator/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
 
     - name: Validate with 'v' prefix
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       if: inputs.allow_v_prefix == 'true'
       with:
         value: ${{ inputs.version }}
@@ -38,7 +38,7 @@ runs:
         error_if_not_valid: ${{ inputs.error_if_not_valid }}
 
     - name: Validate without 'v' prefix
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       if: inputs.allow_v_prefix != 'true'
       with:
         value: ${{ inputs.version }}


### PR DESCRIPTION
Clean up these composite actions to use the `v1.17` tag.