### PR TITLE
Make sure all Terraform artifacts have unique names

### DIFF
--- a/actions/terraform-create-plan-file/action.yml
+++ b/actions/terraform-create-plan-file/action.yml
@@ -120,7 +120,7 @@ runs:
     - name: Create Terraform Plan Output Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.artifact_filename }}
+        name: ${{ inputs.artifact_filename }}-create-plan-file-stdout
         path: ${{ inputs.artifact_filepath }}-create-plan-file-stdout.txt
         if-no-files-found: error        
 
@@ -160,7 +160,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: steps.plan.outcome == 'failure'
       with:
-        name: ${{ inputs.artifact_filename }}
+        name: ${{ inputs.artifact_filename }}-create-plan-file-stderr
         path: ${{ inputs.artifact_filepath }}-create-plan-file-stderr.txt
         if-no-files-found: error        
 

--- a/actions/terraform-fmt-check-recursive/action.yml
+++ b/actions/terraform-fmt-check-recursive/action.yml
@@ -105,7 +105,7 @@ runs:
     - name: Create Terraform Format Check Output Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.artifact_filename }}
+        name: ${{ inputs.artifact_filename }}-fmt-check-stdout
         path: ${{ inputs.artifact_filepath }}-fmt-check-stdout.txt
         if-no-files-found: error        
 
@@ -145,7 +145,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: steps.fmt-check.outcome == 'failure'
       with:
-        name: ${{ inputs.artifact_filename }}
+        name: ${{ inputs.artifact_filename }}-fmt-check-stderr
         path: ${{ inputs.artifact_filepath }}-fmt-check-stderr.txt
         if-no-files-found: error        
 

--- a/actions/terraform-init/action.yml
+++ b/actions/terraform-init/action.yml
@@ -105,7 +105,7 @@ runs:
     - name: Create Terraform Init Output Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.artifact_filename }}
+        name: ${{ inputs.artifact_filename }}-init-stdout
         path: ${{ inputs.artifact_filepath }}-init-stdout.txt
         if-no-files-found: error        
 
@@ -145,7 +145,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: steps.init.outcome == 'failure'
       with:
-        name: ${{ inputs.artifact_filename }}
+        name: ${{ inputs.artifact_filename }}-init-stderr
         path: ${{ inputs.artifact_filepath }}-init-stderr.txt
         if-no-files-found: error        
 

--- a/actions/terraform-show-plan-file/action.yml
+++ b/actions/terraform-show-plan-file/action.yml
@@ -118,7 +118,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: steps.plan-show.outcome == 'success'
       with:
-        name: ${{ env.ARTIFACT_NAME }}
+        name: ${{ env.ARTIFACT_NAME }}-show-plan-file
         path: "${{ env.WORKING_DIRECTORY }}${{ env.ARTIFACT_FILENAME }}*.txt"
         if-no-files-found: error        
 

--- a/actions/terraform-validate/action.yml
+++ b/actions/terraform-validate/action.yml
@@ -105,7 +105,7 @@ runs:
     - name: Create Terraform Validate Output Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.artifact_filename }}
+        name: ${{ inputs.artifact_filename }}-validate-stdout
         path: ${{ inputs.artifact_filepath }}-validate-stdout.txt
         if-no-files-found: error        
 
@@ -145,7 +145,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: steps.validate.outcome == 'failure'
       with:
-        name: ${{ inputs.artifact_filename }}
+        name: ${{ inputs.artifact_filename }}-validate-stderr
         path: ${{ inputs.artifact_filepath }}-validate-stderr.txt
         if-no-files-found: error        
 


### PR DESCRIPTION
Under v3, the artifact names could be appended
to by later 'actions/upload-artifact' calls.  Under v4, that is no longer allowed and causes an error.

Every call to 'actions/upload-artifact' must provide a name unique within the workflow run.