### PR TITLE
Add github_job_runner_spec input on JFrog dotnet build

### DIFF
--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -35,6 +35,11 @@ on:
         type: string
         default: "6.0"
 
+      github_job_runner_spec:
+        description: Which GitHub Runner to use.  Default is 'ubuntu-latest'.
+        type: string
+        default: "ubuntu-latest"
+
       jfrog_api_base_url:
         description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
         required: true
@@ -101,7 +106,7 @@ jobs:
 
   build:
     name: Build (.NET)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.github_job_runner_spec }}
     defaults:
       run:
         working-directory: ${{ inputs.project_directory }}


### PR DESCRIPTION
Include an optional input for `github_job_runner_spec` to allow .NET 3.1 builds to run on a pinned build runner.