### PR TITLE
Add github_job_runner_spec input on JFrog dotnet pack and publish

### DIFF
--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -32,6 +32,11 @@ on:
         type: string
         default: "6.0"
 
+      github_job_runner_spec:
+        description: Which GitHub Runner to use.  Default is 'ubuntu-latest'.
+        type: string
+        default: "ubuntu-latest"
+
       jfrog_api_base_url:
         description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
         required: true
@@ -99,7 +104,7 @@ jobs:
 
   pack:
     name: Pack (.NET)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.github_job_runner_spec }}
     defaults:
       run:
           working-directory: ${{ inputs.project_directory }}

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -35,6 +35,11 @@ on:
         type: string
         default: "6.0"
 
+      github_job_runner_spec:
+        description: Which GitHub Runner to use.  Default is 'ubuntu-latest'.
+        type: string
+        default: "ubuntu-latest"
+
       jfrog_api_base_url:
         description: 'JFrog platform url (for example: https://rimdev.jfrog.io/)'
         required: true
@@ -110,7 +115,7 @@ jobs:
 
   publish:
     name: Publish (.NET)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.github_job_runner_spec }}
     defaults:
       run:
         working-directory: ${{ inputs.project_directory }}


### PR DESCRIPTION
Include an optional input for `github_job_runner_spec` to allow .NET 3.1 pack and publish workflows to run on a pinned build runner.

Follow-up to adding this same input parameter to the build workflow: https://github.com/ritterim/public-github-actions/pull/225