### PR TITLE
Pin to v4.5.6 of jfrog/setup-jfrog-cli for OIDC bug

### DIFF
--- a/.github/workflows/build-dotnet-framework-jfrog.yml
+++ b/.github/workflows/build-dotnet-framework-jfrog.yml
@@ -182,7 +182,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -179,7 +179,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-npm-build-jfrog.yml
+++ b/.github/workflows/dotnet-npm-build-jfrog.yml
@@ -253,7 +253,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-npm-publish-jfrog.yml
+++ b/.github/workflows/dotnet-npm-publish-jfrog.yml
@@ -280,7 +280,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-npm-test-jfrog.yml
+++ b/.github/workflows/dotnet-npm-test-jfrog.yml
@@ -337,7 +337,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -192,7 +192,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -221,7 +221,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -278,7 +278,7 @@ jobs:
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}
 
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/jfrog-publish-aggregate-build-info.yml
+++ b/.github/workflows/jfrog-publish-aggregate-build-info.yml
@@ -158,7 +158,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/jfrog-xray-audit.yml
+++ b/.github/workflows/jfrog-xray-audit.yml
@@ -112,7 +112,7 @@ jobs:
             ~/.nuget/packages
 
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-build-jfrog.yml
+++ b/.github/workflows/npm-build-jfrog.yml
@@ -165,7 +165,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-build-test-publish-v2.yml
+++ b/.github/workflows/npm-build-test-publish-v2.yml
@@ -280,7 +280,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-pack-jfrog.yml
+++ b/.github/workflows/npm-pack-jfrog.yml
@@ -198,7 +198,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:

--- a/.github/workflows/npm-test-jfrog.yml
+++ b/.github/workflows/npm-test-jfrog.yml
@@ -135,7 +135,7 @@ jobs:
 
       # This creates the setup-jfrog-cli-server server ID
       - name: Install JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v4.5.6
         env:
           JF_URL: ${{ env.JFROG_API_BASE_URL }}
         with:


### PR DESCRIPTION
v4.5.7 and later of the jfrog/setup-jfrog-cli GitHub Action have broken the contract of what the default "audience" OIDC value is being passed over to the JFrog Cloud instance from the GitHub Actions run.

The default for this action used to be the GitHub organization's URL, unless you passed in a value for 'oidc-audience' when calling the setup action.  In v4.5.7, they changed the audience default to be 'jfrog-github' -- which breaks existing OIDC Integrations with GitHub.

The workaround for now is either to:

1. Pin to v4.5.6 instead of using the 'v4' tag.

2. Change all your workflows to pass the correct OIDC Audience value.

3. Change your OIDC Integration in the JFrog administration portal.

Based on conversations in issue 270 at https://github.com/jfrog/setup-jfrog-cli/issues we believe that the change to the default value should be reverted and we can eventually go back to using the 'v4' tag here.  We're trying to defer making changes to our OIDC configuration until the outcome of issue 270 is decided.