### PR TITLE
Update all validator steps to use 'v1.17'

### DIFF
--- a/.github/workflows/__pr-build-actions-regex-validator.yml
+++ b/.github/workflows/__pr-build-actions-regex-validator.yml
@@ -15,7 +15,7 @@ on:
 jobs:
 
   pr-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-build-test-public.yml@v1.16.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-build-test-public.yml@v1.17
     with:
       project_directory: actions/regex-validator/
       run_tests: true

--- a/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
+++ b/.github/workflows/calculate-version-with-npm-version-using-pr-labels.yml
@@ -127,12 +127,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/deploy-zip-to-azure-webapps-with-swap.yml
+++ b/.github/workflows/deploy-zip-to-azure-webapps-with-swap.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
 
       - name: Validate inputs.azure_web_app_deploy_subscription_id
-        uses: ritterim/public-github-actions/actions/guid-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/guid-validator@v1.17
         with:
           guid: ${{ env.AZUREDEPLOYSUBSCRIPTIONID }}
 

--- a/.github/workflows/deploy-zip-to-azure-webapps-with-verify.yml
+++ b/.github/workflows/deploy-zip-to-azure-webapps-with-verify.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
 
       - name: Validate inputs.azure_web_app_deploy_subscription_id
-        uses: ritterim/public-github-actions/actions/guid-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/guid-validator@v1.17
         with:
           guid: ${{ env.AZUREDEPLOYSUBSCRIPTIONID }}
 

--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -130,31 +130,31 @@ jobs:
     steps:
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_nuget_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NUGET_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -67,14 +67,14 @@ jobs:
     steps:
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/dotnet-frogbot-private-repo-scan.yml
+++ b/.github/workflows/dotnet-frogbot-private-repo-scan.yml
@@ -76,24 +76,24 @@ jobs:
     steps:
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_nuget_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NUGET_FEED_REPO }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate secrets.jfrog_api_key JWT
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           regex_pattern: '^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$'
           value: ${{ env.JFROG_API_KEY }}

--- a/.github/workflows/dotnet-jfrog-xray-scan.yml
+++ b/.github/workflows/dotnet-jfrog-xray-scan.yml
@@ -62,18 +62,18 @@ jobs:
     steps:
 
       - name: Validate secrets.jfrog_api_key
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           regex_pattern: '^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$'
           value: ${{ secrets.jfrog_api_key }}
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.report_artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.REPORTARTIFACTNAME }}
 

--- a/.github/workflows/dotnet-npm-astro-build-test-publish.yml
+++ b/.github/workflows/dotnet-npm-astro-build-test-publish.yml
@@ -183,78 +183,78 @@ jobs:
     steps:
 
       - name: Validate inputs.publish_artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PUBLISHARTIFACTNAME }}
 
       - name: Validate inputs.test_results_artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.TESTRESULTSARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.npm_package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.NPMPACKAGEJSONFILENAME }}
 
       - name: Validate inputs.npm_project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.NPMPROJECTDIRECTORY }}
 
       - name: Validate inputs.publish_working_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PUBLISHWORKINGDIRECTORY }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.git_hash
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           value: ${{ env.GIT_HASH }}
           regex_pattern: '^([a-fA-F0-9]{40})$'
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.VERSION }}
 
       - name: Validate inputs.astro_target_brand
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           value: ${{ env.TARGET_BRAND }}
           regex_pattern: '^(standard|whitelabel)$'
 
       - name: Validate inputs.astro_target_environment
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           value: ${{ env.TARGET_ENVIRONMENT }}
           regex_pattern: '^(development|staging|production)$'
 
       - name: Validate inputs.astro_target_configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           value: ${{ env.TARGET_CONFIGURATION }}
           regex_pattern: '^(release|debug)$'
 
       - name: Validate ZIPFILENAME
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ZIPFILENAME }}
 

--- a/.github/workflows/dotnet-npm-build-jfrog.yml
+++ b/.github/workflows/dotnet-npm-build-jfrog.yml
@@ -178,57 +178,57 @@ jobs:
     steps:
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.dotnet_project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.DOTNETPROJECTDIRECTORY }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_npm_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NPM_FEED_REPO }}
 
       - name: Validate inputs.jfrog_nuget_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NUGET_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
 
       - name: Validate inputs.npm_package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.NPMPACKAGEJSONFILENAME }}
 
       - name: Validate inputs.npm_project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.NPMPROJECTDIRECTORY }}
 
       - name: Validate inputs.npm_run_build_script_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-\:]{5,35}$'
           value: ${{ env.NPM_RUN_BUILD_SCRIPT_NAME }}
 
       - name: Validate inputs.npm_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.NPMVERSION }}
 

--- a/.github/workflows/dotnet-npm-publish-jfrog.yml
+++ b/.github/workflows/dotnet-npm-publish-jfrog.yml
@@ -180,76 +180,76 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_npm_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NPM_FEED_REPO }}
 
       - name: Validate inputs.jfrog_nuget_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NUGET_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
 
       - name: Validate inputs.npm_package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.NPMPACKAGEJSONFILENAME }}
 
       - name: Validate inputs.npm_project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.NPMPROJECTDIRECTORY }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.publish_working_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PUBLISH_WORKING_DIRECTORY }}
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.VERSION }}
 
       - name: Validate PUBLISHARTIFACTDIRECTORY
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PUBLISHARTIFACTDIRECTORY }}
 
       - name: Validate ZIPFILENAME
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ZIPFILENAME }}
 
@@ -259,7 +259,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17.0
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/dotnet-npm-publish-jfrog.yml
+++ b/.github/workflows/dotnet-npm-publish-jfrog.yml
@@ -259,7 +259,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/dotnet-npm-test-jfrog.yml
+++ b/.github/workflows/dotnet-npm-test-jfrog.yml
@@ -249,56 +249,56 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_npm_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NPM_FEED_REPO }}
 
       - name: Validate inputs.jfrog_nuget_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NUGET_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
 
       - name: Validate inputs.npm_package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.NPMPACKAGEJSONFILENAME }}
 
       - name: Validate inputs.npm_project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.NPMPROJECTDIRECTORY }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate RIMDEVTESTS__SQL__PASSWORD (must be 8-250 chars)
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         if: inputs.docker_mssql_image != ''
         with:
           value: ${{ env.RIMDEVTESTS__SQL__PASSWORD }}

--- a/.github/workflows/dotnet-npm-test.yml
+++ b/.github/workflows/dotnet-npm-test.yml
@@ -166,41 +166,41 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.npm_package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.NPMPACKAGEJSONFILENAME }}
 
       - name: Validate inputs.npm_project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.NPMPROJECTDIRECTORY }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate RIMDEVTESTS__SQL__PASSWORD (must be 8-250 chars)
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         if: inputs.docker_mssql_image != ''
         with:
           value: ${{ env.RIMDEVTESTS__SQL__PASSWORD }}
           regex_pattern: "^.{8,250}$"
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -133,35 +133,35 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.VERSION }}
 

--- a/.github/workflows/dotnet-pack.yml
+++ b/.github/workflows/dotnet-pack.yml
@@ -73,34 +73,34 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.VERSION }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -147,50 +147,50 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.publish_working_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PUBLISH_WORKING_DIRECTORY }}
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.VERSION }}
 
       - name: Validate PUBLISHARTIFACTDIRECTORY
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PUBLISHARTIFACTDIRECTORY }}
 
       - name: Validate ZIPFILENAME
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ZIPFILENAME }}
 

--- a/.github/workflows/dotnet-push-github.yml
+++ b/.github/workflows/dotnet-push-github.yml
@@ -35,12 +35,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ inputs.artifact_name }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ inputs.project_directory }}
 

--- a/.github/workflows/dotnet-push-jfrog-artifactory.yml
+++ b/.github/workflows/dotnet-push-jfrog-artifactory.yml
@@ -67,22 +67,22 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ inputs.artifact_name }}
 
       - name: Validate inputs.jfrog_artifactory_repository
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_ARTIFACTORY_REPOSITORY }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ inputs.project_directory }}
 
       - name: Validate secrets.jfrog_api_key
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           regex_pattern: '^[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$'
           value: ${{ secrets.jfrog_api_key }}

--- a/.github/workflows/dotnet-push-myget.yml
+++ b/.github/workflows/dotnet-push-myget.yml
@@ -43,12 +43,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ inputs.artifact_name }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ inputs.project_directory }}
 

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -206,41 +206,41 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.configuration
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           case_sensitive: false
           regex_pattern: "^debug|release$"
           value: ${{ env.CONFIGURATION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_nuget_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NUGET_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate RIMDEVTESTS__SQL__PASSWORD (must be 8-250 chars)
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         if: inputs.docker_mssql_image != ''
         with:
           value: ${{ env.RIMDEVTESTS__SQL__PASSWORD }}

--- a/.github/workflows/extract-version-from-npm-package-json.yml
+++ b/.github/workflows/extract-version-from-npm-package-json.yml
@@ -110,12 +110,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/jfrog-xray-audit.yml
+++ b/.github/workflows/jfrog-xray-audit.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
@@ -89,17 +89,17 @@ jobs:
 #TODO: Validate inputs.jfrog_xray_watch_list
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.report_artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.REPORTARTIFACTNAME }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/npm-build-jfrog.yml
+++ b/.github/workflows/npm-build-jfrog.yml
@@ -118,29 +118,29 @@ jobs:
     steps:
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_npm_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NPM_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/npm-build-test-public.yml
+++ b/.github/workflows/npm-build-test-public.yml
@@ -80,12 +80,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/npm-build-test-publish-v2.yml
+++ b/.github/workflows/npm-build-test-publish-v2.yml
@@ -214,18 +214,18 @@ jobs:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_npm_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NPM_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}

--- a/.github/workflows/npm-build-test-publish.yml
+++ b/.github/workflows/npm-build-test-publish.yml
@@ -115,58 +115,58 @@ jobs:
     steps:
 
       - name: Validate inputs.environment
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with:
           value: ${{ env.ENVIRONMENT }}
           regex_pattern: '^(localhost|development|production)$'
 
       - name: Validate inputs.publish_artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PUBLISHARTIFACTNAME }}
 
       - name: Validate inputs.test_results_artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.TESTRESULTSARTIFACTNAME }}
 
       - name: Validate inputs.npm_package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.NPMPACKAGEJSONFILENAME }}
 
       - name: Validate inputs.npm_project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.NPMPROJECTDIRECTORY }}
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.publish_artifact_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PUBLISHARTIFACTDIRECTORY }}
 
       - name: Validate inputs.publish_working_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PUBLISHWORKINGDIRECTORY }}
 
       - name: Validate inputs.informational_version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.INFORMATIONALVERSION }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.VERSION }}
 
       - name: Validate ZIPFILENAME
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ZIPFILENAME }}
 

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -87,12 +87,12 @@ jobs:
     steps:
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/npm-create-version-tag.yml
+++ b/.github/workflows/npm-create-version-tag.yml
@@ -88,27 +88,27 @@ jobs:
     steps:
 
       - name: Validate inputs.npm_scope
-        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.17
         with:
           npm_scope: ${{ env.NPMSCOPE }}
 
       - name: Validate inputs.npm_package_name
-        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.17
         with:
           package_name: ${{ env.NPMPACKAGENAME }}
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.NPMVERSION }}
 

--- a/.github/workflows/npm-pack-jfrog.yml
+++ b/.github/workflows/npm-pack-jfrog.yml
@@ -138,44 +138,44 @@ jobs:
     steps:
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_npm_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NPM_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
 
       - name: Validate inputs.npm_scope
-        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.17
         with:
           npm_scope: ${{ env.NPMSCOPE }}
 
       - name: Validate inputs.npm_package_name
-        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.17
         with:
           package_name: ${{ env.NPMPACKAGENAME }}
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.NPMVERSION }}
 

--- a/.github/workflows/npm-pack.yml
+++ b/.github/workflows/npm-pack.yml
@@ -88,27 +88,27 @@ jobs:
     steps:
 
       - name: Validate inputs.npm_scope
-        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/npm-package-scope-validator@v1.17
         with:
           npm_scope: ${{ env.NPMSCOPE }}
 
       - name: Validate inputs.npm_package_name
-        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/npm-package-name-validator@v1.17
         with:
           package_name: ${{ env.NPMPACKAGENAME }}
 
       - name: Validate inputs.package_json_filename
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.PACKAGEJSONFILENAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 
       - name: Validate inputs.version
-        uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
         with:
           version: ${{ env.NPMVERSION }}
 

--- a/.github/workflows/npm-publish-to-github-packages.yml
+++ b/.github/workflows/npm-publish-to-github-packages.yml
@@ -37,12 +37,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.artifact_file_path
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTFILEPATH }}          
 

--- a/.github/workflows/npm-publish-to-myget.yml
+++ b/.github/workflows/npm-publish-to-myget.yml
@@ -42,12 +42,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.artifact_file_path
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTFILEPATH }} 
 

--- a/.github/workflows/npm-publish-to-npmjs-org.yml
+++ b/.github/workflows/npm-publish-to-npmjs-org.yml
@@ -48,12 +48,12 @@ jobs:
     steps:
 
       - name: Validate inputs.artifact_name
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTNAME }}
 
       - name: Validate inputs.artifact_file_path
-        uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
         with:
           file_name: ${{ env.ARTIFACTFILEPATH }} 
 

--- a/.github/workflows/npm-test-jfrog.yml
+++ b/.github/workflows/npm-test-jfrog.yml
@@ -96,24 +96,24 @@ jobs:
     steps:
 
       - name: Validate inputs.jfrog_build_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ inputs.jfrog_build_name }}
 
       - name: Validate inputs.jfrog_npm_feed_repo
-        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/jfrog-artifactory-repository-name-validator@v1.17
         with:
           name: ${{ env.JFROG_NPM_FEED_REPO }}
 
       - name: Validate inputs.jfrog_oidc_provider_name
-        uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/regex-validator@v1.17
         with: # This regex pattern is a bit of a guess
           regex_pattern: '^[A-Za-z0-9\-]{5,55}$'
           value: ${{ env.JFROG_OIDC_PROVIDER_NAME }}
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
 
       - name: Validate inputs.project_directory
-        uses: ritterim/public-github-actions/actions/path-name-validator@v1.16.2
+        uses: ritterim/public-github-actions/actions/path-name-validator@v1.17
         with:
           path_name: ${{ env.PROJECTDIRECTORY }}
 

--- a/actions/create-github-release/action.yml
+++ b/actions/create-github-release/action.yml
@@ -28,17 +28,17 @@ runs:
   steps:
 
     - name: Validate inputs.github_repository
-      uses: ritterim/public-github-actions/actions/github-org-repository-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/github-org-repository-validator@v1.17
       with:
         github_repository: ${{ inputs.github_repository }}
 
     - name: Validate inputs.github_token
-      uses: ritterim/public-github-actions/actions/github-token-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/github-token-validator@v1.17
       with:
         token: ${{ inputs.github_token }}
 
     - name: Validate inputs.version_tag
-      uses: ritterim/public-github-actions/actions/version-number-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/version-number-validator@v1.17
       env:
         VERSIONTAG: ${{ inputs.version_tag }}
       with:

--- a/actions/regex-validator/package-lock.json
+++ b/actions/regex-validator/package-lock.json
@@ -3453,12 +3453,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -5155,16 +5155,16 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -5225,9 +5225,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5791,9 +5791,9 @@
       "dev": true
     },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -8959,12 +8959,12 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -15140,12 +15140,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browserslist": {
@@ -16364,16 +16364,16 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "dependencies": {
         "glob-parent": {
@@ -16427,9 +16427,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -16819,9 +16819,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true
     },
     "import-fresh": {
@@ -19138,12 +19138,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },

--- a/forks/persist-workspace/action.yml
+++ b/forks/persist-workspace/action.yml
@@ -50,13 +50,13 @@ runs:
   steps:
 
     - name: Validate inputs.artifact_name
-      uses: ritterim/public-github-actions/actions/file-name-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/file-name-validator@v1.17
       with:
         file_name: ${{ inputs.artifact_name }}
         required: false
 
     - name: Validate inputs.artifact_name_suffix
-      uses: ritterim/public-github-actions/actions/regex-validator@v1.16.2
+      uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         regex_pattern: '^[a-zA-Z0-9]{2,40}$'
         required: false


### PR DESCRIPTION
Most of the validator steps were using v1.16.x, which is now out of date.  The validators haven't changed in a while so it's a moot point.

However.  Moving to the floating v1.17 tag will make it easier to pickup any bug fixes / vulnerability fixes down the road.