### PR TITLE
Upgrade 'forks/persist-workspace' action to v1.17

### DIFF
--- a/.github/workflows/dotnet-build-jfrog.yml
+++ b/.github/workflows/dotnet-build-jfrog.yml
@@ -230,7 +230,7 @@ jobs:
 
       - name: Persist Workspace
         id: persist-workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}
 

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Persist Workspace
         id: persist-workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}
 

--- a/.github/workflows/dotnet-npm-build-jfrog.yml
+++ b/.github/workflows/dotnet-npm-build-jfrog.yml
@@ -345,7 +345,7 @@ jobs:
 
       - name: Persist Workspace
         id: persist-workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17.0
         with:
           artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}
 

--- a/.github/workflows/dotnet-npm-build-jfrog.yml
+++ b/.github/workflows/dotnet-npm-build-jfrog.yml
@@ -345,7 +345,7 @@ jobs:
 
       - name: Persist Workspace
         id: persist-workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}
 

--- a/.github/workflows/dotnet-npm-test-jfrog.yml
+++ b/.github/workflows/dotnet-npm-test-jfrog.yml
@@ -315,7 +315,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         if: inputs.run_tests == true
         with:
           action: retrieve

--- a/.github/workflows/dotnet-npm-test-jfrog.yml
+++ b/.github/workflows/dotnet-npm-test-jfrog.yml
@@ -315,7 +315,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17.0
         if: inputs.run_tests == true
         with:
           action: retrieve

--- a/.github/workflows/dotnet-npm-test.yml
+++ b/.github/workflows/dotnet-npm-test.yml
@@ -229,7 +229,7 @@ jobs:
           cache-dependency-path: "${{ inputs.npm_project_directory }}${{ inputs.npm_package_json_filename }}"
 
       - name: npm-config-github-packages-repository
-        uses: ritterim/public-github-actions/actions/npm-config-github-packages-repository@v1.16.0
+        uses: ritterim/public-github-actions/actions/npm-config-github-packages-repository@v1.17
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dotnet-pack-jfrog.yml
+++ b/.github/workflows/dotnet-pack-jfrog.yml
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/dotnet-publish-jfrog.yml
+++ b/.github/workflows/dotnet-publish-jfrog.yml
@@ -214,7 +214,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/dotnet-push-jfrog-artifactory.yml
+++ b/.github/workflows/dotnet-push-jfrog-artifactory.yml
@@ -104,7 +104,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/dotnet-test-jfrog.yml
+++ b/.github/workflows/dotnet-test-jfrog.yml
@@ -271,7 +271,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         if: inputs.run_tests == true
         with:
           action: retrieve

--- a/.github/workflows/generate-github-token-from-github-app.yml
+++ b/.github/workflows/generate-github-token-from-github-app.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Generate GH Token from GH App
         id: generate_token
-        uses: ritterim/public-github-actions/forks/github-app-token@v1.16.0
+        uses: ritterim/public-github-actions/forks/github-app-token@v1.17
         with:
           app_id: ${{ inputs.gh_app_id }}
           private_key: ${{ secrets.gh_app_private_key }}

--- a/.github/workflows/jfrog-publish-aggregate-build-info.yml
+++ b/.github/workflows/jfrog-publish-aggregate-build-info.yml
@@ -151,7 +151,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/npm-build-jfrog.yml
+++ b/.github/workflows/npm-build-jfrog.yml
@@ -208,7 +208,7 @@ jobs:
 
       - name: Persist Workspace
         id: persist-workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.3
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}
 

--- a/.github/workflows/npm-build-test-public.yml
+++ b/.github/workflows/npm-build-test-public.yml
@@ -128,6 +128,6 @@ jobs:
       - name: Persist Workspace
         id: persist-workspace
         if: inputs.persist_workspace == true
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -141,6 +141,6 @@ jobs:
       - name: Persist Workspace
         id: persist-workspace
         if: inputs.persist_workspace == true
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           artifact_name_suffix: ${{ inputs.persisted_workspace_artifact_suffix }}

--- a/.github/workflows/npm-pack-jfrog.yml
+++ b/.github/workflows/npm-pack-jfrog.yml
@@ -185,7 +185,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/npm-pack.yml
+++ b/.github/workflows/npm-pack.yml
@@ -113,7 +113,7 @@ jobs:
           version: ${{ env.NPMVERSION }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/npm-test-jfrog.yml
+++ b/.github/workflows/npm-test-jfrog.yml
@@ -128,7 +128,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         with:
           action: retrieve
           artifact_name: ${{ inputs.persisted_workspace_artifact_name }}

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -59,7 +59,7 @@ jobs:
         run: echo "The 'inputs.run_tests' value is FALSE, skipping tests!"
 
       - name: Restore Workspace
-        uses: ritterim/public-github-actions/forks/persist-workspace@v1.16.0
+        uses: ritterim/public-github-actions/forks/persist-workspace@v1.17
         if: inputs.run_tests == true
         with:
           action: retrieve


### PR DESCRIPTION
Use the floating tag for all instances of forks/persist-workspace.

The last change to this action was April 2024 (v1.15.4) when it was upgraded to use the v4 upload/download actions.  Therefore moving from v1.16.0 to v1.17 should have no impact.

Moving to the floating v1.17 tag will make it easier to pickup any bug fixes / vulnerability fixes down the road.