### PR TITLE
Update READMEs to show use of floating 'v1.17' tag

### DIFF
--- a/actions/attach-artifact-to-release/README.md
+++ b/actions/attach-artifact-to-release/README.md
@@ -9,7 +9,7 @@ Attach artifact from the workflow run to a GitHub Release.
 
 ```
       - name: Attach Artifact to GitHub Release
-        uses: ritterim/public-github-actions/attach-artifact-to-release@v1.16.0
+        uses: ritterim/public-github-actions/attach-artifact-to-release@v1.17
         with:
           artifact_name: ${{ inputs.artifact_name }}
           artifact_file_path: ${{ inputs.artifact_file_path }}

--- a/actions/calculate-version-from-txt-using-github-run-id/README.md
+++ b/actions/calculate-version-from-txt-using-github-run-id/README.md
@@ -42,7 +42,7 @@ Note that you *must* have a `version.txt` file in the root of the repository wit
 
       - name: Calculate Version
         id: version
-        uses: ritterim/public-github-actions/actions/calculate-version-from-txt-using-github-run-id@v1.17.1
+        uses: ritterim/public-github-actions/actions/calculate-version-from-txt-using-github-run-id@v1.17
         with:
           version_suffix: "-alpha${{ github.run_number }}"
           github_run_id_baseline: 6100000000

--- a/actions/create-github-release/README.md
+++ b/actions/create-github-release/README.md
@@ -9,7 +9,7 @@ A composite action which will create a GitHub Release using an existing tag in t
 
 ```
       - name: Create GitHub Release
-        uses: ritterim/public-github-actions/create-github-release@v1.16.0
+        uses: ritterim/public-github-actions/create-github-release@v1.17
         with:
           github_repository: ${{ github.repository }}
           github_token: ${{ github.token }}

--- a/actions/npm-config-github-packages-repository/README.md
+++ b/actions/npm-config-github-packages-repository/README.md
@@ -23,7 +23,7 @@ You must have requested `packages: read` (or `packages:write` to publish) in you
 
 ```
       - name: npm-config-github-packages-repository
-        uses: ritterim/public-github-actions/actions/npm-config-github-packages-repository@v1.16.0
+        uses: ritterim/public-github-actions/actions/npm-config-github-packages-repository@v1.17
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/actions/npm-config-myget-packages-repository/README.md
+++ b/actions/npm-config-myget-packages-repository/README.md
@@ -13,7 +13,7 @@ WARN: It's not designed for use outside of our organization due to the hardcoded
 
 ```
       - name: npm-config-myget-packages-repository
-        uses: ritterim/public-github-actions/actions/npm-config-myget-packages-repository@v1.16.0
+        uses: ritterim/public-github-actions/actions/npm-config-myget-packages-repository@v1.17
         with:
           myget_api_key: ${{ secrets.myget_api_key }}
 ```

--- a/actions/npm-config-npmjs-org-registry/README.md
+++ b/actions/npm-config-npmjs-org-registry/README.md
@@ -11,7 +11,7 @@ This uses `npm config set` commands to set the API key and scope registry for th
 
 ```
       - name: npm-config-npmjs-org-registry
-        uses: ritterim/public-github-actions/actions/npm-config-npmjs-org-registry@v1.16.0
+        uses: ritterim/public-github-actions/actions/npm-config-npmjs-org-registry@v1.17
         with:
           npmjs_api_key: ${{ secrets.npmjs_api_key }}
 ```

--- a/forks/github-app-token/README.md
+++ b/forks/github-app-token/README.md
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: ritterim/public-github-actions/forks/github-app-token@v1.16.0
+        uses: ritterim/public-github-actions/forks/github-app-token@v1.17
         with:
           app_id: ${{ secrets.APP_ID }}
 


### PR DESCRIPTION
Our current recommendation is that we reference the floating 'v1.17' tag in our downstream actions so that we immediately pickup on any bug fixes in a newer patch release on the 'v1.17' line.