### PR TITLE
Make rimbot_registry_access_key optional, add notes

### DIFF
--- a/actions/terraform-apply-plan-file/action.yml
+++ b/actions/terraform-apply-plan-file/action.yml
@@ -26,8 +26,8 @@ inputs:
     default: terraform.tfplan
 
   rimbot_registry_access_key:
-    description: The Azure table storage account access key for RIMbot (rimlogsdevrimbot).
-    required: true
+    description: The Azure table storage account access key for RIMbot (rimlogsdevrimbot).  This value is passed into our Terraform inputs so that RIMbot can write the Azure Web App information into an Azure Storage Table.  It only matters for Terraform plan/apply cycles where we are using that Powershell script.
+    required: false
 
   workflow_run_title: 
     required: true


### PR DESCRIPTION
This input is only used in some of our Terraform plan/apply cycles where we deploy Azure Web Apps.  RIMbot is our internal GitHub issue/PR tool that we use for deployments, restarts, swaps, etc.

In order for it to work, we have to keep a list of the web apps that RIMbot is supposed to know about and we refresh that using our Terraform plans and a Powershell script.