### PR TITLE
Add .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ out
 Thumbs.db
 
 .vscode/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` to `.gitignore` so Claude Code's local settings file is not accidentally committed

## Test plan
- [ ] Verify `.claude/settings.local.json` is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)