### PR TITLE
docs: document PR-only testing scope for build counter action

### DIFF
--- a/.github/workflows/test-build-counter-allocator-workflow.yml
+++ b/.github/workflows/test-build-counter-allocator-workflow.yml
@@ -2,7 +2,10 @@ name: "Test: Build Counter Allocator"
 
 # Standalone testing workflow for the build-counter-allocator reusable workflow.
 # Allocates a build counter and displays the result for validation.
-# Triggered on push to master and pull requests when files in the action directory change.
+# Triggered on pull requests when files in the action directory change.
+# NOTE: Testing is PR-only (not push/post-merge) because the action resides in a shared
+# public repo. GitHub App private key cannot be safely exposed to public repos. Post-merge
+# logic would only be tested if the action were in an isolated private repository.
 
 permissions:
   contents: read
@@ -12,11 +15,6 @@ concurrency:
   cancel-in-progress: false
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'actions/allocate-build-counter/**'
   pull_request:
     paths:
       - 'actions/allocate-build-counter/**'

--- a/.github/workflows/test-calculate-version-using-build-counter-allocator-workflow.yml
+++ b/.github/workflows/test-calculate-version-using-build-counter-allocator-workflow.yml
@@ -2,7 +2,10 @@ name: "Test: Calculate Version Using Build Counter Allocator"
 
 # Standalone testing workflow for the calculate-version-using-build-counter-allocator reusable workflow.
 # Calculates a version number and displays the result for validation.
-# Triggered on push to master and pull requests when related files change.
+# Triggered on pull requests when related files change.
+# NOTE: Testing is PR-only (not push/post-merge) because the action resides in a shared
+# public repo. GitHub App private key cannot be safely exposed to public repos. Post-merge
+# logic would only be tested if the action were in an isolated private repository.
 
 permissions:
   contents: read
@@ -12,12 +15,6 @@ concurrency:
   cancel-in-progress: false
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - '.github/workflows/calculate-version-using-build-counter-allocator.yml'
-      - 'actions/allocate-build-counter/**'
   pull_request:
     paths:
       - '.github/workflows/calculate-version-using-build-counter-allocator.yml'

--- a/actions/allocate-build-counter/BUILD-COUNTER-TECHNICAL.md
+++ b/actions/allocate-build-counter/BUILD-COUNTER-TECHNICAL.md
@@ -170,4 +170,7 @@ The build counter repository itself is a pure tag store with no executable conte
 |----------|---------|---------|
 | `build-counter-allocator.yml` | `workflow_call`, `workflow_dispatch` | Allocate a counter only; no version calculation |
 | `calculate-version-using-build-counter-allocator.yml` | `workflow_call`, `workflow_dispatch` | Allocate a counter and compute a full semver. The `version_source` input selects between `version_txt` (read `major.minor` from `version.txt`) and `parameters` (use the `major_minor_version` input) |
-| `test-build-counter-allocator-workflow.yml` | `push`, `pull_request`, `workflow_dispatch` | Internal smoke test for `build-counter-allocator.yml`; not intended to be called by consumers |
+| `test-build-counter-allocator-workflow.yml` | `pull_request`, `workflow_dispatch` | Internal smoke test for `build-counter-allocator.yml` (PR context only); not intended to be called by consumers |
+| `test-calculate-version-using-build-counter-allocator-workflow.yml` | `pull_request`, `workflow_dispatch` | Internal smoke test for `calculate-version-using-build-counter-allocator.yml` (PR context only); not intended to be called by consumers |
+
+**Note on test workflows**: Testing is limited to PR contexts (pull_request and manual workflow_dispatch) due to the shared public repository constraint. The GitHub App private key is sensitive and cannot be safely exposed to public repos — org secrets are restricted by default. Post-merge (push event) integration tests would require explicit allowlist configuration, which creates unacceptable security risk given the scope of other actions in this repository.

--- a/actions/allocate-build-counter/BUILD-COUNTER-USAGE.md
+++ b/actions/allocate-build-counter/BUILD-COUNTER-USAGE.md
@@ -174,6 +174,14 @@ On GitHub Enterprise with multiple orgs and no enterprise-level secrets, the sec
 
 **Audit log** (GitHub Enterprise) — every installation token generation is logged. Anomalous generation volume or unexpected timing is detectable.
 
+### Testing Considerations
+
+Because the private key is sensitive, test workflows for this action are typically limited to PR contexts only (read-only mode, no counter writes). Post-merge integration tests require the private key to be configured as an accessible secret, which is only appropriate for **isolated private repositories** containing only the build counter action and tests.
+
+If the action lives in a shared public repository alongside other actions (as in `ritterim/public-github-actions`), GitHub org-level secrets are restricted from public repos by default — only explicit allowlist entries grant access. Exposing the private key to a public repo creates unacceptable risk given the wider scope of other actions in that repository.
+
+For your own infrastructure, if the build counter is in an isolated private repository, configuring the private key is appropriate and post-merge testing can be enabled.
+
 ---
 
 ## Using the Build Counter in Your Repository

--- a/actions/allocate-build-counter/README.md
+++ b/actions/allocate-build-counter/README.md
@@ -133,6 +133,14 @@ Pull requests callers will also get zero by design.
 
 A tag push failure followed by a retry will re-read the counter state from the remote. If the old tag was deleted before the new one was pushed successfully, and the push then failed, a subsequent retry will see no tags and restart from 1. This is rare but possible under network errors. Increase `max_retries` to reduce the window.
 
+## Testing
+
+This action is tested via pull requests only. Post-merge (push event) testing is **not** performed because the action resides in a shared public repository. GitHub App private keys cannot be safely exposed to public repositories — org secrets are restricted by default, and explicitly allowing a public repo would create an unacceptable security surface given the scope of other actions in this repository.
+
+**For CI/CD integration testing** (where you own a private repository containing only this action or actions that depend on it), the GitHub App private key can be safely configured and post-merge testing can be enabled.
+
+**For pre-merge testing**, the PR-based test workflows are sufficient — they use the GitHub token available in PR context (read-only mode) to validate behavior and error paths.
+
 ## Requirements
 
 ### GitHub App


### PR DESCRIPTION
- Remove push triggers from test-build-counter-allocator-workflow.yml and test-calculate-version-using-build-counter-allocator-workflow.yml
- Add comments explaining why testing is PR-only: GitHub App private key cannot be safely exposed to public repos (org secrets restricted by default)
- Add Testing section to README.md
- Add Testing Considerations section to BUILD-COUNTER-USAGE.md
- Update Workflow Inventory in BUILD-COUNTER-TECHNICAL.md with note on PR-only scope and when post-merge testing would be appropriate

Co-Authored-By: Claude Haiku 4.5