### PR TITLE
ci: checkout public-github-actions in reusable workflows

### DIFF
--- a/.github/workflows/build-counter-allocator.yml
+++ b/.github/workflows/build-counter-allocator.yml
@@ -99,11 +99,20 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - name: Checkout Project
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - uses: ./actions/allocate-build-counter
+      - name: Checkout public-github-actions
+        uses: actions/checkout@v4
+        with:
+          repository: ritterim/public-github-actions
+          path: .public-github-actions
+          fetch-depth: 1
+
+      - name: Allocate Build Counter
+        uses: ./.public-github-actions/actions/allocate-build-counter
         id: alloc
         with:
           counter_key: ${{ inputs.counter_key }}

--- a/.github/workflows/calculate-version-using-build-counter-allocator.yml
+++ b/.github/workflows/calculate-version-using-build-counter-allocator.yml
@@ -224,9 +224,16 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 1
 
+      - name: Checkout public-github-actions
+        uses: actions/checkout@v4
+        with:
+          repository: ritterim/public-github-actions
+          path: .public-github-actions
+          fetch-depth: 1
+
       - name: Allocate Build Counter
         if: ${{ !inputs.build_number }}
-        uses: ./actions/allocate-build-counter
+        uses: ./.public-github-actions/actions/allocate-build-counter
         id: allocate
         with:
           counter_key: ${{ inputs.counter_key }}


### PR DESCRIPTION
Both build-counter-allocator.yml and calculate-version-using-build-counter-allocator.yml reusable workflows try to use ./actions/allocate-build-counter, but when called as reusable workflows from other repos, the local action path fails because it's trying to find the action in the calling repo's workspace, not in public-github-actions.

Add explicit checkout of public-github-actions repo into .public-github-actions directory, then reference the action with the full path.

Co-Authored-By: Claude Haiku 4.5