### PR TITLE
ci: pin build-counter action to SHA in reusable workflows

### DIFF
--- a/.github/workflows/build-counter-allocator.yml
+++ b/.github/workflows/build-counter-allocator.yml
@@ -104,15 +104,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Checkout public-github-actions
-        uses: actions/checkout@v4
-        with:
-          repository: ritterim/public-github-actions
-          path: .public-github-actions
-          fetch-depth: 1
-
       - name: Allocate Build Counter
-        uses: ./.public-github-actions/actions/allocate-build-counter
+        uses: ritterim/public-github-actions/actions/allocate-build-counter@79ec3d558b7dc11a85bbdd86ee6f1c9a3ba02b82
         id: alloc
         with:
           counter_key: ${{ inputs.counter_key }}

--- a/.github/workflows/calculate-version-using-build-counter-allocator.yml
+++ b/.github/workflows/calculate-version-using-build-counter-allocator.yml
@@ -224,16 +224,9 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 1
 
-      - name: Checkout public-github-actions
-        uses: actions/checkout@v4
-        with:
-          repository: ritterim/public-github-actions
-          path: .public-github-actions
-          fetch-depth: 1
-
       - name: Allocate Build Counter
         if: ${{ !inputs.build_number }}
-        uses: ./.public-github-actions/actions/allocate-build-counter
+        uses: ritterim/public-github-actions/actions/allocate-build-counter@79ec3d558b7dc11a85bbdd86ee6f1c9a3ba02b82
         id: allocate
         with:
           counter_key: ${{ inputs.counter_key }}


### PR DESCRIPTION
## Summary

- Replace local-path `./.public-github-actions/actions/allocate-build-counter` (which required a second `actions/checkout` of this repo) with a direct cross-repo reference pinned to a commit SHA.
- Pinned to `79ec3d558b7dc11a85bbdd86ee6f1c9a3ba02b82`, the last commit that modified `action.yml` or `action.ps1`. Bumping the pin is a deliberate action when the upstream action changes.
- Drops the now-unnecessary `public-github-actions` checkout step from both reusable workflows.

## Why

PR #253 worked but cloned the whole repo on every run and silently floated to the default branch (no `ref:` on the checkout), giving no real version pinning. Direct `org/repo/path@sha` is the canonical pattern for cross-repo composite actions and gives reproducible builds.

## Test plan

- [ ] `test-build-counter-allocator-workflow.yml` run succeeds on this branch
- [ ] `test-calculate-version-using-build-counter-allocator-workflow.yml` run succeeds on this branch
- [ ] Downstream consumer (e.g. `ritterim/terraform-test-application`) green when calling the reusable workflow at this ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)