### PR TITLE
fix: require private_key for build counter allocation

### DIFF
--- a/actions/allocate-build-counter/action.yml
+++ b/actions/allocate-build-counter/action.yml
@@ -50,7 +50,7 @@ runs:
   steps:
 
     - id: app-token
-      if: ${{ inputs.app_id != '' }}
+      if: ${{ inputs.app_id != '' && inputs.private_key != '' }}
       uses: actions/create-github-app-token@v2
       with:
         app-id: ${{ inputs.app_id }}


### PR DESCRIPTION
Prevent GitHub App token creation from failing silently when private_key is not provided. Previously, the condition only checked app_id, allowing the create-github-app-token step to run without the required private key. Now both app_id and private_key must be present.

On PR context where private_key is intentionally omitted, the action now correctly skips token creation and returns build_number=0.

Co-Authored-By: Claude Haiku 4.5