### PR TITLE
ci: pin allocate-build-counter action to fixed SHA

### DIFF
--- a/.github/workflows/build-counter-allocator.yml
+++ b/.github/workflows/build-counter-allocator.yml
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 1
 
       - name: Allocate Build Counter
-        uses: ritterim/public-github-actions/actions/allocate-build-counter@79ec3d558b7dc11a85bbdd86ee6f1c9a3ba02b82
+        uses: ritterim/public-github-actions/actions/allocate-build-counter@4ee324cceb1d83fdf6a629a619e8ddbb3a046b8b
         id: alloc
         with:
           counter_key: ${{ inputs.counter_key }}

--- a/.github/workflows/calculate-version-using-build-counter-allocator.yml
+++ b/.github/workflows/calculate-version-using-build-counter-allocator.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Allocate Build Counter
         if: ${{ !inputs.build_number }}
-        uses: ritterim/public-github-actions/actions/allocate-build-counter@79ec3d558b7dc11a85bbdd86ee6f1c9a3ba02b82
+        uses: ritterim/public-github-actions/actions/allocate-build-counter@4ee324cceb1d83fdf6a629a619e8ddbb3a046b8b
         id: allocate
         with:
           counter_key: ${{ inputs.counter_key }}


### PR DESCRIPTION
Update workflows to use the latest allocate-build-counter action with private_key validation fix.

Co-Authored-By: Claude Haiku 4.5