### PR TITLE
fix: log git output on clone failure

### DIFF
--- a/actions/allocate-build-counter/action.ps1
+++ b/actions/allocate-build-counter/action.ps1
@@ -215,13 +215,16 @@ function Invoke-GitCommand {
     $displayArgs = Format-GitArgsForDisplay -Arguments $finalArgs
     Write-Verbose "git $($displayArgs -join ' ')"
 
-    if ($CaptureOutput) {
-        $output = & git @finalArgs 2>&1
-    } else {
-        & git @finalArgs 2>&1 | Out-Null
-    }
+    $output = & git @finalArgs 2>&1
 
     if ($LASTEXITCODE -ne 0 -and -not $IgnoreErrors) {
+        if ($output) {
+            $outputLines = @($output | ForEach-Object { "$_" } | Where-Object { $_ })
+            $redactedLines = Format-GitArgsForDisplay -Arguments $outputLines
+            foreach ($line in $redactedLines) {
+                Write-Verbose "git output: $line"
+            }
+        }
         Write-Error "git command failed with exit code $LASTEXITCODE"
         exit 1
     }


### PR DESCRIPTION
Previously Invoke-GitCommand piped git stdout and stderr to Out-Null for non-capture calls, swallowing the actual error message. A clone failure surfaced only as "git command failed with exit code 128" with no indication of whether the cause was auth, missing repo, network, or something else.

Now the output is always captured. On failure, each line is run through Format-GitArgsForDisplay (redacts tokens/credentials) and emitted via Write-Verbose so the real git message appears in the Actions log.

Co-Authored-By: Claude Sonnet 4.6