### PR TITLE
ci: bump allocate-build-counter SHA

### DIFF
--- a/.github/workflows/build-counter-allocator.yml
+++ b/.github/workflows/build-counter-allocator.yml
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 1
 
       - name: Allocate Build Counter
-        uses: ritterim/public-github-actions/actions/allocate-build-counter@4ee324cceb1d83fdf6a629a619e8ddbb3a046b8b
+        uses: ritterim/public-github-actions/actions/allocate-build-counter@88bb57763d4166c08e89ddb8765814523a50af9c
         id: alloc
         with:
           counter_key: ${{ inputs.counter_key }}

--- a/.github/workflows/calculate-version-using-build-counter-allocator.yml
+++ b/.github/workflows/calculate-version-using-build-counter-allocator.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Allocate Build Counter
         if: ${{ !inputs.build_number }}
-        uses: ritterim/public-github-actions/actions/allocate-build-counter@4ee324cceb1d83fdf6a629a619e8ddbb3a046b8b
+        uses: ritterim/public-github-actions/actions/allocate-build-counter@88bb57763d4166c08e89ddb8765814523a50af9c
         id: allocate
         with:
           counter_key: ${{ inputs.counter_key }}


### PR DESCRIPTION
Pull in fix from f470a13 (log git output on clone failure).

Co-Authored-By: Claude Sonnet 4.6