### PR TITLE
fix: use Bearer auth for GitHub App tokens

### DIFF
--- a/actions/allocate-build-counter/action.ps1
+++ b/actions/allocate-build-counter/action.ps1
@@ -195,10 +195,10 @@ function Format-GitArgsForDisplay {
     param([string[]] $Arguments)
     # Redact embedded tokens and credentials before logging.
     # Pattern 1: scheme://userinfo:token@host -> scheme://userinfo:***@host
-    # Pattern 2: Authorization: token ... -> Authorization: token ***
+    # Pattern 2: Authorization: Bearer/token ... -> Authorization: Bearer/token ***
     return $Arguments | ForEach-Object {
         $_ -replace '(://[^:/\s@]+):[^@\s]+@', '$1:***@' `
-           -replace '(Authorization: token\s+)\S+', '$1***'
+           -replace '(Authorization: (?:Bearer|token)\s+)\S+', '$1***'
     }
 }
 
@@ -262,7 +262,7 @@ function Initialize-CounterRepository {
     Remove-Item -Path $clonePath -Recurse -Force -ErrorAction SilentlyContinue
 
     # Clone with token via header to keep it out of git config
-    $authHeader = "Authorization: token $Token"
+    $authHeader = "Authorization: Bearer $Token"
     Invoke-GitCommand @('-c', "http.extraheader=$authHeader", 'clone', '--filter=blob:none', '--no-checkout', '--depth=1', $resolvedUrl, $clonePath)
 
     # Ensure remote URL has no embedded credentials
@@ -281,7 +281,7 @@ function Get-NextBuildNumber {
     )
 
     Write-Verbose "Fetching tags for prefix: $TagPrefix"
-    $fetchArgs = if ($Token) { @('-c', "http.extraheader=Authorization: token $Token") + @('fetch', '--tags', '--force') } else { @('fetch', '--tags', '--force') }
+    $fetchArgs = if ($Token) { @('-c', "http.extraheader=Authorization: Bearer $Token") + @('fetch', '--tags', '--force') } else { @('fetch', '--tags', '--force') }
     Invoke-GitCommand $fetchArgs -RepoPath $RepoPath -IgnoreErrors
 
     $allTags = Invoke-GitCommand @('tag', '-l', "${TagPrefix}*") -RepoPath $RepoPath -IgnoreErrors -CaptureOutput | Where-Object { $_ }
@@ -320,7 +320,7 @@ function Push-BuildNumberTag {
     Invoke-GitCommand @('tag', $NewTag) -RepoPath $RepoPath
 
     Write-Verbose "Pushing tag to origin"
-    $pushArgs = if ($Token) { @('-c', "http.extraheader=Authorization: token $Token") + @('push', 'origin', "refs/tags/${NewTag}") } else { @('push', 'origin', "refs/tags/${NewTag}") }
+    $pushArgs = if ($Token) { @('-c', "http.extraheader=Authorization: Bearer $Token") + @('push', 'origin', "refs/tags/${NewTag}") } else { @('push', 'origin', "refs/tags/${NewTag}") }
     Invoke-GitCommand $pushArgs -RepoPath $RepoPath -IgnoreErrors
     if ($LASTEXITCODE -eq 0) {
         return $true
@@ -350,7 +350,7 @@ function Remove-OldBuildNumberTags {
     if ($tagsToDelete) {
         Write-Verbose "Cleaning up $($tagsToDelete.Count) old tag(s)"
         foreach ($oldTag in $tagsToDelete) {
-            $deleteArgs = if ($Token) { @('-c', "http.extraheader=Authorization: token $Token") + @('push', 'origin', '--delete', $oldTag) } else { @('push', 'origin', '--delete', $oldTag) }
+            $deleteArgs = if ($Token) { @('-c', "http.extraheader=Authorization: Bearer $Token") + @('push', 'origin', '--delete', $oldTag) } else { @('push', 'origin', '--delete', $oldTag) }
             Invoke-GitCommand $deleteArgs -RepoPath $RepoPath -IgnoreErrors
             if ($LASTEXITCODE -ne 0) {
                 Write-Warning "Failed to delete old tag $oldTag (git exit code $LASTEXITCODE) - tag will be retried on next allocation"

--- a/actions/allocate-build-counter/action.yml
+++ b/actions/allocate-build-counter/action.yml
@@ -67,4 +67,5 @@ runs:
         COUNTER_REPO_OWNER: ${{ inputs.counter_repo_owner }}
         COUNTER_REPO_NAME: ${{ inputs.counter_repo_name }}
         ACTION_PATH: ${{ github.action_path }}
+        GIT_TERMINAL_PROMPT: "0"
       run: '& "$env:ACTION_PATH/action.ps1"'


### PR DESCRIPTION
App installation tokens (ghs_*) require Authorization: Bearer, not the OAuth `token` scheme. Also set GIT_TERMINAL_PROMPT=0 to fail fast instead of attempting a /dev/tty credential prompt.

Co-Authored-By: Claude Sonnet 4.6