### PR TITLE
fix: use Basic auth for git clone/push/fetch

### DIFF
--- a/actions/allocate-build-counter/action.ps1
+++ b/actions/allocate-build-counter/action.ps1
@@ -191,14 +191,20 @@ function Get-ResolvedRepository {
     return @{ Value = 'local-repo'; Source = 'fallback default' }
 }
 
+function Get-GitAuthHeader {
+    param([string] $Token)
+    $b64 = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("x-access-token:$Token"))
+    return "Authorization: Basic $b64"
+}
+
 function Format-GitArgsForDisplay {
     param([string[]] $Arguments)
     # Redact embedded tokens and credentials before logging.
     # Pattern 1: scheme://userinfo:token@host -> scheme://userinfo:***@host
-    # Pattern 2: Authorization: Bearer/token ... -> Authorization: Bearer/token ***
+    # Pattern 2: Authorization: Bearer/token/Basic ... -> Authorization: <scheme> ***
     return $Arguments | ForEach-Object {
         $_ -replace '(://[^:/\s@]+):[^@\s]+@', '$1:***@' `
-           -replace '(Authorization: (?:Bearer|token)\s+)\S+', '$1***'
+           -replace '(Authorization: (?:Bearer|token|Basic)\s+)\S+', '$1***'
     }
 }
 
@@ -262,7 +268,7 @@ function Initialize-CounterRepository {
     Remove-Item -Path $clonePath -Recurse -Force -ErrorAction SilentlyContinue
 
     # Clone with token via header to keep it out of git config
-    $authHeader = "Authorization: Bearer $Token"
+    $authHeader = Get-GitAuthHeader -Token $Token
     Invoke-GitCommand @('-c', "http.extraheader=$authHeader", 'clone', '--filter=blob:none', '--no-checkout', '--depth=1', $resolvedUrl, $clonePath)
 
     # Ensure remote URL has no embedded credentials
@@ -281,7 +287,7 @@ function Get-NextBuildNumber {
     )
 
     Write-Verbose "Fetching tags for prefix: $TagPrefix"
-    $fetchArgs = if ($Token) { @('-c', "http.extraheader=Authorization: Bearer $Token") + @('fetch', '--tags', '--force') } else { @('fetch', '--tags', '--force') }
+    $fetchArgs = if ($Token) { @('-c', "http.extraheader=$(Get-GitAuthHeader -Token $Token)") + @('fetch', '--tags', '--force') } else { @('fetch', '--tags', '--force') }
     Invoke-GitCommand $fetchArgs -RepoPath $RepoPath -IgnoreErrors
 
     $allTags = Invoke-GitCommand @('tag', '-l', "${TagPrefix}*") -RepoPath $RepoPath -IgnoreErrors -CaptureOutput | Where-Object { $_ }
@@ -320,7 +326,7 @@ function Push-BuildNumberTag {
     Invoke-GitCommand @('tag', $NewTag) -RepoPath $RepoPath
 
     Write-Verbose "Pushing tag to origin"
-    $pushArgs = if ($Token) { @('-c', "http.extraheader=Authorization: Bearer $Token") + @('push', 'origin', "refs/tags/${NewTag}") } else { @('push', 'origin', "refs/tags/${NewTag}") }
+    $pushArgs = if ($Token) { @('-c', "http.extraheader=$(Get-GitAuthHeader -Token $Token)") + @('push', 'origin', "refs/tags/${NewTag}") } else { @('push', 'origin', "refs/tags/${NewTag}") }
     Invoke-GitCommand $pushArgs -RepoPath $RepoPath -IgnoreErrors
     if ($LASTEXITCODE -eq 0) {
         return $true
@@ -350,7 +356,7 @@ function Remove-OldBuildNumberTags {
     if ($tagsToDelete) {
         Write-Verbose "Cleaning up $($tagsToDelete.Count) old tag(s)"
         foreach ($oldTag in $tagsToDelete) {
-            $deleteArgs = if ($Token) { @('-c', "http.extraheader=Authorization: Bearer $Token") + @('push', 'origin', '--delete', $oldTag) } else { @('push', 'origin', '--delete', $oldTag) }
+            $deleteArgs = if ($Token) { @('-c', "http.extraheader=$(Get-GitAuthHeader -Token $Token)") + @('push', 'origin', '--delete', $oldTag) } else { @('push', 'origin', '--delete', $oldTag) }
             Invoke-GitCommand $deleteArgs -RepoPath $RepoPath -IgnoreErrors
             if ($LASTEXITCODE -ne 0) {
                 Write-Warning "Failed to delete old tag $oldTag (git exit code $LASTEXITCODE) - tag will be retried on next allocation"

--- a/actions/allocate-build-counter/tests/utilities.tests.ps1
+++ b/actions/allocate-build-counter/tests/utilities.tests.ps1
@@ -24,6 +24,20 @@ Describe 'Set-GitHubOutput' {
     }
 }
 
+Describe 'Get-GitAuthHeader' {
+    It 'returns Authorization: Basic with base64(x-access-token:TOKEN)' {
+        $token = 'ghs_placeholder-test-fixture-not-a-credential'
+        $header = Get-GitAuthHeader -Token $token
+        $expected = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("x-access-token:$token"))
+        $header | Should -Be "Authorization: Basic $expected"
+    }
+
+    It 'starts with Authorization: Basic' {
+        $header = Get-GitAuthHeader -Token 'any-token'
+        $header | Should -Match '^Authorization: Basic '
+    }
+}
+
 Describe 'Format-GitArgsForDisplay' {
     It 'redacts token in basic-auth URL' {
         # Use a fixture password that is obviously not a credential to avoid
@@ -32,6 +46,14 @@ Describe 'Format-GitArgsForDisplay' {
         $redacted = Format-GitArgsForDisplay -Arguments @('clone', "https://x-access-token:${fixturePassword}@example.test/org/repo.git", '/tmp/x')
         $redacted -join ' ' | Should -Match '://x-access-token:\*\*\*@example.test'
         $redacted -join ' ' | Should -Not -Match $fixturePassword
+    }
+
+    It 'redacts Basic auth token in http.extraheader config arg' {
+        $b64 = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes('x-access-token:ghs_placeholder-test-fixture-not-a-credential'))
+        $args1 = @('-c', "http.extraheader=Authorization: Basic $b64", 'clone', 'https://github.com/org/repo.git', '/tmp/x')
+        $redacted = Format-GitArgsForDisplay -Arguments $args1
+        $redacted -join ' ' | Should -Match 'Authorization: Basic \*\*\*'
+        $redacted -join ' ' | Should -Not -Match $b64
     }
 
     It 'leaves token-free URLs untouched' {


### PR DESCRIPTION
## Summary

- GitHub's git HTTPS server rejects `Authorization: Bearer` for git operations (`clone`, `fetch`, `push`)
- Tested locally: Bearer → `remote: invalid credentials`; `token` → falls back to credential prompt; Basic → success
- Adds `Get-GitAuthHeader` helper that encodes `x-access-token:<token>` as HTTP Basic, used in all four git call sites (clone, fetch, push tag, delete tag)
- Updates `Format-GitArgsForDisplay` to redact `Authorization: Basic` in addition to Bearer/token

## Root cause

PR #259 switched to `Bearer` which works for REST API calls but not for the git Smart HTTP protocol. The correct scheme for GitHub App installation tokens in git is Basic auth with username `x-access-token`.

## Test plan

- [ ] All 97 Pester tests pass locally
- [ ] Re-run failed job in `terraform-test-application` after SHA bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)