### PR TITLE
ci: bump allocate-build-counter SHA (Basic auth fix)

### DIFF
--- a/.github/workflows/build-counter-allocator.yml
+++ b/.github/workflows/build-counter-allocator.yml
@@ -105,7 +105,7 @@ jobs:
           fetch-depth: 1
 
       - name: Allocate Build Counter
-        uses: ritterim/public-github-actions/actions/allocate-build-counter@e3c97fd80de648f59ed6bb0c20f10a8b1f4e346e
+        uses: ritterim/public-github-actions/actions/allocate-build-counter@76245ce1da126f3c0f2c95a82cf17b03762c9212
         id: alloc
         with:
           counter_key: ${{ inputs.counter_key }}

--- a/.github/workflows/calculate-version-using-build-counter-allocator.yml
+++ b/.github/workflows/calculate-version-using-build-counter-allocator.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Allocate Build Counter
         if: ${{ !inputs.build_number }}
-        uses: ritterim/public-github-actions/actions/allocate-build-counter@e3c97fd80de648f59ed6bb0c20f10a8b1f4e346e
+        uses: ritterim/public-github-actions/actions/allocate-build-counter@76245ce1da126f3c0f2c95a82cf17b03762c9212
         id: allocate
         with:
           counter_key: ${{ inputs.counter_key }}


### PR DESCRIPTION
## Summary

- Bumps `allocate-build-counter` action SHA to `76245ce` in both consuming workflows
- Picks up the Basic auth fix from PR #261

## Affected workflows

- `.github/workflows/build-counter-allocator.yml`
- `.github/workflows/calculate-version-using-build-counter-allocator.yml`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)