### PR TITLE
fix: update npm-config-github-packages token regex

### DIFF
--- a/actions/npm-config-github-packages-repository/README.md
+++ b/actions/npm-config-github-packages-repository/README.md
@@ -15,8 +15,6 @@ You must have requested `packages: read` (or `packages:write` to publish) in you
 
 ## Notes 
 
-- GitHub App tokens can not currently be used to access a GitHub Packages NPM registry.
- 
 - The NPM scope must match your GitHub organization name.  GitHub Packages will not let you push up NPM packages for another scope.
 
 # Example

--- a/actions/npm-config-github-packages-repository/action.yml
+++ b/actions/npm-config-github-packages-repository/action.yml
@@ -11,12 +11,10 @@ inputs:
 
   github_token:
     description: A GitHub Token that can be used to access the GitHub Packages repository.
-    type: string
     required: true
 
   npm_scope:
     description: The NPM 'scope' value to use.  Default is 'ritterim' as it needs to match the GitHub organization value.
-    type: string
     required: false
     default: ritterim
 
@@ -35,7 +33,7 @@ runs:
       env: 
         GHTOKEN: ${{ inputs.github_token }}
       run: |
-        echo "${GHTOKEN}" | grep -E '^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$'
+        echo "${GHTOKEN}" | grep -E '^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9_]+|v[0-9]\.[0-9a-f]{40})$'
 
     - name: Verify current NPM config
       shell: bash


### PR DESCRIPTION
## Summary

- Relax `github_pat_` token regex from hardcoded `{22}_{59}` lengths to `[a-zA-Z0-9_]+` — guards against silent breakage if GitHub changes fine-grained PAT length
- Remove `type: string` from composite action inputs (not valid in composite action schema)
- Remove stale note claiming GitHub App tokens cannot be used with GitHub Packages NPM registry

All documented GitHub credential types (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`, `github_pat_`, legacy `v[0-9].`) remain covered by the regex.

## Test plan

- [ ] Verify `GITHUB_TOKEN` (classic `ghs_` format) passes validation in a workflow run
- [ ] Verify fine-grained PAT (`github_pat_...`) passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)