### PR TITLE
fix: npm-config token debug info, silence grep

### DIFF
--- a/actions/npm-config-github-packages-repository/action.yml
+++ b/actions/npm-config-github-packages-repository/action.yml
@@ -33,7 +33,9 @@ runs:
       env: 
         GHTOKEN: ${{ inputs.github_token }}
       run: |
-        echo "${GHTOKEN}" | grep -E '^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9_]+|v[0-9]\.[0-9a-f]{40})$'
+        echo "Token length: ${#GHTOKEN}"
+        echo "Token type: $(echo "$GHTOKEN" | grep -oE '^(ghp_|ghs_|gho_|ghu_|github_pat_|v[0-9]\.)' || echo 'unknown')"
+        echo "${GHTOKEN}" | grep -qE '^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9_]+|v[0-9]\.[0-9a-f]{40})$'
 
     - name: Verify current NPM config
       shell: bash


### PR DESCRIPTION
## Summary

- Add `Token length` and `Token type` debug output to help troubleshoot token validation failures
- Switch `grep` to `-q` (quiet) so the full token value is never echoed to the Actions log

## Changes

`actions/npm-config-github-packages-repository/action.yml` — validate step now emits safe metadata (length + type prefix) before the pattern match, and grep no longer prints the matched line.