### PR TITLE
fix: expand ghs_ token regex for stateless format

### DIFF
--- a/actions/github-token-validator/action.yml
+++ b/actions/github-token-validator/action.yml
@@ -1,6 +1,8 @@
 name: github-token-validator
 description: Validate that the value looks like a modern GitHub authentication token.
 # https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
+# https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
+# https://github.blog/engineering/platform-security/behind-githubs-new-authentication-token-formats/
 author: RIMdev <RIMdev@RitterIM.com>
 branding:
   icon: 'check-square'  
@@ -28,6 +30,6 @@ runs:
       uses: ritterim/public-github-actions/actions/regex-validator@v1.17
       with:
         value: ${{ inputs.token }}
-        regex_pattern: '^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$'
+        regex_pattern: '^(gh[pousr]_[A-Za-z0-9._-]{36,}|github_pat_[a-zA-Z0-9_]+|v[0-9]\.[0-9a-f]{40})$'
         required: ${{ inputs.required }}
         error_if_not_valid: ${{ inputs.error_if_not_valid }}

--- a/actions/npm-config-github-packages-repository/action.yml
+++ b/actions/npm-config-github-packages-repository/action.yml
@@ -28,16 +28,18 @@ runs:
       with:
         npm_scope: ${{ inputs.npm_scope }}
 
-    # https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
-    # https://github.blog/engineering/platform-security/behind-githubs-new-authentication-token-formats/
-    - name: Validate inputs.github_token
+    - name: Debug inputs.github_token
       shell: bash
-      env: 
+      env:
         GHTOKEN: ${{ inputs.github_token }}
       run: |
         echo "Token length: ${#GHTOKEN}"
         echo "Token type: $(echo "$GHTOKEN" | grep -oE '^(ghp_|ghs_|gho_|ghu_|github_pat_|v[0-9]\.)' || echo 'unknown')"
-        echo "${GHTOKEN}" | grep -qE '^(gh[pousr]_[A-Za-z0-9._-]{36,}|github_pat_[a-zA-Z0-9_]+|v[0-9]\.[0-9a-f]{40})$'
+
+    - name: Validate inputs.github_token
+      uses: ritterim/public-github-actions/actions/github-token-validator@v1.17
+      with:
+        token: ${{ inputs.github_token }}
 
     - name: Verify current NPM config
       shell: bash

--- a/actions/npm-config-github-packages-repository/action.yml
+++ b/actions/npm-config-github-packages-repository/action.yml
@@ -28,6 +28,8 @@ runs:
       with:
         npm_scope: ${{ inputs.npm_scope }}
 
+    # https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
+    # https://github.blog/engineering/platform-security/behind-githubs-new-authentication-token-formats/
     - name: Validate inputs.github_token
       shell: bash
       env: 
@@ -35,7 +37,7 @@ runs:
       run: |
         echo "Token length: ${#GHTOKEN}"
         echo "Token type: $(echo "$GHTOKEN" | grep -oE '^(ghp_|ghs_|gho_|ghu_|github_pat_|v[0-9]\.)' || echo 'unknown')"
-        echo "${GHTOKEN}" | grep -qE '^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9_]+|v[0-9]\.[0-9a-f]{40})$'
+        echo "${GHTOKEN}" | grep -qE '^(gh[pousr]_[A-Za-z0-9._-]{36,}|github_pat_[a-zA-Z0-9_]+|v[0-9]\.[0-9a-f]{40})$'
 
     - name: Verify current NPM config
       shell: bash


### PR DESCRIPTION
## Summary

- Expand `gh[pousr]_` token regex to accept `.` and `-` characters required by the new stateless `ghs_` format (`ghs_APPID_JWT`)
- Remove upper bound of 251 — new stateless tokens are ~520 characters
- Loosen `github_pat_` pattern from rigid `{22}_{59}` structure to `[a-zA-Z0-9_]+`
- Apply same fixes to `actions/github-token-validator`
- Refactor `npm-config-github-packages-repository` to delegate token validation to `github-token-validator` instead of inline grep

GitHub began rolling out the stateless installation token format on 2026-04-27. Tokens in the old format (~40 chars, alphanumeric only) and new format (~520 chars, contains dots) must both be accepted.

See also: See #264